### PR TITLE
refactor(logging): write important logs to file instead of console

### DIFF
--- a/packages/desktop/src/infrastructure/command/shellPath.ts
+++ b/packages/desktop/src/infrastructure/command/shellPath.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
 import { ShellDetector } from './shellDetector';
+import { fileLogger } from '../logging/fileLogger';
 
 // Try to import app from electron (might not be available in all contexts)
 let app: typeof import('electron').app | undefined;
@@ -58,11 +59,11 @@ export function getShellPath(): string {
   }
   isFirstCall = false;
 
-  console.log('[ShellPath] Starting PATH detection...');
-  console.log(`[ShellPath] Platform: ${process.platform}`);
-  console.log(`[ShellPath] Current process PATH: ${process.env.PATH ? process.env.PATH.substring(0, 200) + '...' : 'not set'}`);
-  console.log(`[ShellPath] Shell environment: ${process.env.SHELL || 'not set'}`);
-  console.log(`[ShellPath] Home directory: ${os.homedir()}`);
+  fileLogger.info('ShellPath', 'Starting PATH detection', {
+    platform: process.platform,
+    shell: process.env.SHELL || 'not set',
+    home: os.homedir()
+  });
 
   const isWindows = process.platform === 'win32';
   const pathSep = getPathSeparator();
@@ -75,8 +76,6 @@ export function getShellPath(): string {
     
     if (isWindows) {
       // On Windows, use cmd.exe to get PATH
-      console.log('Getting Windows PATH using cmd.exe');
-      
       shellPath = execSync('echo %PATH%', {
         encoding: 'utf8',
         timeout: 5000,
@@ -106,25 +105,20 @@ export function getShellPath(): string {
       const shellInfo = ShellDetector.getDefaultShell();
       const shell = shellInfo.path;
       const isLinux = process.platform === 'linux';
-      
-      console.log(`[ShellPath] Detected shell: ${shell} (${shellInfo.name})`);
-      
+
+      fileLogger.debug('ShellPath', 'Detected shell', { shell, name: shellInfo.name, isLinux });
+
       // For Linux, avoid slow interactive shell startup
       // Use non-interactive mode for better performance
-      const shellCommand = isLinux 
+      const shellCommand = isLinux
         ? `${shell} -c 'echo $PATH'`  // Fast non-interactive mode for Linux
         : `${shell} -l -i -c 'echo $PATH'`;  // Keep login shell for macOS
-      
-      console.log(`[ShellPath] Unix/Linux PATH detection - Shell: ${shell}, isLinux: ${isLinux}`);
-      console.log(`[ShellPath] Shell command: ${shellCommand}`);
       
       // Execute the command to get the PATH
       // For packaged apps, ALWAYS use login shell to get the user's real PATH
       const isPackaged = process.env.NODE_ENV === 'production' || 'pkg' in process || app?.isPackaged;
       
       if (isPackaged) {
-        console.log('Running in packaged app, using login shell to get full PATH...');
-        
         // Use minimal base PATH - just enough to find the shell
         const minimalPath = '/usr/bin:/bin';
         
@@ -148,12 +142,11 @@ export function getShellPath(): string {
           }
           
           const fullCommand = `${shell} -c '${sourceCommand}echo $PATH'`;
-          console.log('Executing shell command to get PATH:', fullCommand);
-          
+
           shellPath = execSync(fullCommand, {
             encoding: 'utf8',
             timeout: isLinux ? 3000 : 10000,  // Shorter timeout for Linux
-            env: { 
+            env: {
               PATH: minimalPath,
               SHELL: shell,
               USER: os.userInfo().username,
@@ -162,27 +155,25 @@ export function getShellPath(): string {
               ZDOTDIR: process.env.ZDOTDIR || homeDir
             }
           }).trim();
-          console.log('Successfully loaded user PATH from shell config files');
-        } catch (error) {
-          console.error('Failed to load PATH from shell config:', error);
-          
+          fileLogger.debug('ShellPath', 'Loaded PATH from shell config', { method: 'source' });
+        } catch {
           // Try the standard login shell approach
           try {
             shellPath = execSync(shellCommand, {
               encoding: 'utf8',
               timeout: isLinux ? 3000 : 10000,  // Shorter timeout for Linux
-              env: { 
-                PATH: minimalPath,
+              env: {
+                PATH: '/usr/bin:/bin',
                 SHELL: shell,
                 USER: os.userInfo().username,
                 HOME: os.homedir()
               }
             }).trim();
-            console.log('Loaded PATH using login shell flags');
-          } catch (loginError) {
-            console.error('Failed to load PATH from login shell:', loginError);
+            fileLogger.debug('ShellPath', 'Loaded PATH from login shell', { method: 'login' });
+          } catch {
             // Fallback to current PATH + common locations
             shellPath = process.env.PATH || '';
+            fileLogger.debug('ShellPath', 'Using fallback PATH', { method: 'env' });
           }
         }
       } else {
@@ -193,25 +184,18 @@ export function getShellPath(): string {
             timeout: 2000,
             env: process.env
           }).trim();
-          console.log(`[ShellPath] Quick PATH retrieval succeeded`);
-        } catch (quickError) {
-          console.log(`[ShellPath] Quick PATH retrieval failed: ${quickError instanceof Error ? quickError.message : quickError}`);
-          console.log(`[ShellPath] Falling back to login shell approach...`);
+        } catch {
           shellPath = execSync(shellCommand, {
             encoding: 'utf8',
             timeout: isLinux ? 3000 : 10000,  // Shorter timeout for Linux
             env: process.env
           }).trim();
-          console.log(`[ShellPath] Login shell PATH retrieval succeeded`);
         }
       }
     }
-    
-    console.log(`[ShellPath] Retrieved shell PATH (${shellPath.split(pathSep).length} entries): ${shellPath.substring(0, 200)}...`);
-    
+
     // Combine with current process PATH to ensure we don't lose anything
     const currentPath = process.env.PATH || '';
-    console.log(`[ShellPath] Current process PATH has ${currentPath.split(pathSep).length} entries`);
     
     // Also include npm global bin directories
     const additionalPaths: string[] = [];
@@ -219,7 +203,6 @@ export function getShellPath(): string {
     
     // Skip npm/yarn checks on Linux for better performance (they're usually in PATH already)
     if (!isLinux) {
-      console.log(`[ShellPath] Checking for npm/yarn global paths (non-Linux)...`);
       // Try to get npm global bin directory
       try {
         const npmBin = execSync('npm bin -g', { 
@@ -316,7 +299,6 @@ export function getShellPath(): string {
     // Add user-configured additional paths
     const userAdditionalPaths = getAdditionalPaths();
     if (userAdditionalPaths.length > 0) {
-      console.log(`[ShellPath] Adding ${userAdditionalPaths.length} user-configured paths`);
       // Expand ~ to home directory and Windows environment variables
       const expandedUserPaths = userAdditionalPaths.map(p => {
         // Expand tilde for Unix/macOS
@@ -345,19 +327,19 @@ export function getShellPath(): string {
     
     cachedPath = Array.from(combinedPaths).filter(p => p).join(pathSep);
     const pathEntries = cachedPath.split(pathSep);
-    console.log(`[ShellPath] Final combined PATH has ${pathEntries.length} entries`);
-    console.log(`[ShellPath] Added ${additionalPaths.length} additional paths`);
-    console.log(`[ShellPath] First few PATH entries: ${pathEntries.slice(0, 5).join(', ')}`);
-    console.log(`[ShellPath] PATH loading completed successfully`);
-    
+
+    fileLogger.info('ShellPath', 'PATH loaded successfully', {
+      entries: pathEntries.length,
+      additionalPaths: additionalPaths.length,
+      sample: pathEntries.slice(0, 5)
+    });
+
     return cachedPath;
   } catch (error) {
-    console.error('[ShellPath] ERROR: Failed to get shell PATH:', error);
-    console.error(`[ShellPath] Error details: ${error instanceof Error ? error.stack : 'No stack trace available'}`);
+    fileLogger.error('ShellPath', 'Failed to get shell PATH', error instanceof Error ? error : undefined);
     
     if (!isWindows) {
       // Try alternative method: read shell config files directly (Unix/macOS only)
-      console.log('[ShellPath] Attempting fallback: reading shell config files directly...');
       try {
         const homeDir = os.homedir();
         const shellConfigPaths = [
@@ -367,18 +349,15 @@ export function getShellPath(): string {
           path.join(homeDir, '.profile'),
           path.join(homeDir, '.zprofile')
         ];
-        
-        console.log(`[ShellPath] Checking shell config files: ${shellConfigPaths.join(', ')}`);
-        let extractedPaths: string[] = [];
-        
+
+        const extractedPaths: string[] = [];
+
         for (const configPath of shellConfigPaths) {
           if (fs.existsSync(configPath)) {
-            console.log(`[ShellPath] Reading config file: ${configPath}`);
             const content = fs.readFileSync(configPath, 'utf8');
             // Look for PATH exports
             const pathMatches = content.match(/export\s+PATH=["']?([^"'\n]+)["']?/gm);
             if (pathMatches) {
-              console.log(`[ShellPath] Found ${pathMatches.length} PATH exports in ${configPath}`);
               pathMatches.forEach(match => {
                 const pathValue = match.replace(/export\s+PATH=["']?/, '').replace(/["']?$/, '');
                 // Expand $PATH references
@@ -391,31 +370,24 @@ export function getShellPath(): string {
             }
           }
         }
-        
+
         if (extractedPaths.length > 0) {
-          console.log(`[ShellPath] Found ${extractedPaths.length} PATH entries from config files`);
           const combinedPaths = new Set(extractedPaths.join(pathSep).split(pathSep).filter(p => p));
           cachedPath = Array.from(combinedPaths).join(pathSep);
-          console.log(`[ShellPath] Fallback successful - PATH has ${cachedPath.split(pathSep).length} entries`);
+          fileLogger.info('ShellPath', 'Loaded PATH from config files', { entries: cachedPath.split(pathSep).length });
           return cachedPath;
-        } else {
-          console.log('[ShellPath] No PATH entries found in config files');
         }
-      } catch (configError) {
-        console.error('[ShellPath] ERROR: Failed to read shell config files:', configError);
-        console.error(`[ShellPath] Config error details: ${configError instanceof Error ? configError.stack : 'No stack trace'}`);
+      } catch {
+        // Continue to final fallback
       }
     }
-    
+
     // Final fallback to process PATH
-    const fallbackPath = isWindows 
+    const fallbackPath = isWindows
       ? process.env.PATH || 'C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem'
       : process.env.PATH || '/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin';
-    
-    console.error(`[ShellPath] CRITICAL: Using final fallback PATH`);
-    console.error(`[ShellPath] Fallback PATH: ${fallbackPath}`);
-    console.error(`[ShellPath] This may indicate a serious PATH loading issue on ${process.platform}`);
-    
+
+    fileLogger.error('ShellPath', 'Using fallback PATH', undefined);
     return fallbackPath;
   }
 }
@@ -425,41 +397,36 @@ export function getShellPath(): string {
  */
 export function clearShellPathCache(): void {
   cachedPath = null;
-  console.log('[ShellPath] PATH cache cleared - will be rebuilt on next access');
+  fileLogger.state('ShellPath', 'PATH cache cleared');
 }
 
 /**
  * Find an executable in the shell PATH
  */
 export function findExecutableInPath(executable: string): string | null {
-  console.log(`[ShellPath] Finding executable: ${executable}`);
   const shellPath = getShellPath();
   const pathSep = getPathSeparator();
   const paths = shellPath.split(pathSep);
   const isWindows = process.platform === 'win32';
-  
-  console.log(`[ShellPath] Searching in ${paths.length} PATH directories`);
-  
+
   // On Windows, executables might have .exe, .cmd, or .bat extensions
-  const executableNames = isWindows 
+  const executableNames = isWindows
     ? [executable, `${executable}.exe`, `${executable}.cmd`, `${executable}.bat`]
     : [executable];
-  
-  let searchedPaths = 0;
+
   for (const dir of paths) {
     for (const execName of executableNames) {
       const fullPath = path.join(dir, execName);
-      searchedPaths++;
       try {
         if (isWindows) {
           // On Windows, check if file exists
           fs.accessSync(fullPath, fs.constants.F_OK);
-          console.log(`[ShellPath] Found executable at: ${fullPath}`);
+          fileLogger.debug('ShellPath', `Found executable: ${executable}`, { path: fullPath });
           return fullPath;
         } else {
           // On Unix, check if the executable exists and is executable
           execSync(`test -x "${fullPath}"`, { stdio: 'ignore' });
-          console.log(`[ShellPath] Found executable at: ${fullPath}`);
+          fileLogger.debug('ShellPath', `Found executable: ${executable}`, { path: fullPath });
           return fullPath;
         }
       } catch {
@@ -467,8 +434,7 @@ export function findExecutableInPath(executable: string): string | null {
       }
     }
   }
-  
-  console.error(`[ShellPath] Executable '${executable}' not found after searching ${searchedPaths} paths`);
-  console.error(`[ShellPath] First few paths searched: ${paths.slice(0, 5).join(', ')}`);
+
+  fileLogger.error('ShellPath', `Executable not found: ${executable}`);
   return null;
 }

--- a/packages/desktop/src/infrastructure/logging/fileLogger.ts
+++ b/packages/desktop/src/infrastructure/logging/fileLogger.ts
@@ -1,0 +1,202 @@
+/**
+ * Simple file logger for infrastructure modules.
+ * Writes to ~/.snowtree/logs/ without requiring ConfigManager dependency.
+ * Use this for logging important state changes, command executions, and debug info
+ * that should be preserved for troubleshooting but not shown in console.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { homedir } from 'os';
+import { app } from 'electron';
+
+class FileLogger {
+  private static instance: FileLogger;
+  private logDir: string;
+  private logStream: fs.WriteStream | null = null;
+  private currentLogFile: string = '';
+  private currentDate: string = '';
+  private readonly MAX_LOG_SIZE = 5 * 1024 * 1024; // 5MB per file
+  private readonly MAX_LOG_FILES = 10;
+  private currentLogSize = 0;
+  private initPromise: Promise<void> | null = null;
+
+  private constructor() {
+    const isDev = process.argv.includes('--snowtree-dev');
+    const baseDir = process.env.SNOWTREE_DIR || path.join(homedir(), isDev ? '.snowtree_dev' : '.snowtree');
+    this.logDir = path.join(baseDir, 'logs');
+  }
+
+  static getInstance(): FileLogger {
+    if (!FileLogger.instance) {
+      FileLogger.instance = new FileLogger();
+    }
+    return FileLogger.instance;
+  }
+
+  private getDateStr(): string {
+    return new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+  }
+
+  private getTimestamp(): string {
+    return new Date().toISOString().replace('T', ' ').substring(0, 23);
+  }
+
+  private async ensureLogFile(): Promise<void> {
+    const dateStr = this.getDateStr();
+
+    // Check if we need to switch to a new day's file
+    if (dateStr !== this.currentDate || !this.logStream) {
+      this.currentDate = dateStr;
+
+      // Close existing stream
+      if (this.logStream) {
+        this.logStream.end();
+        this.logStream = null;
+      }
+
+      // Ensure log directory exists
+      if (!fs.existsSync(this.logDir)) {
+        fs.mkdirSync(this.logDir, { recursive: true });
+      }
+
+      this.currentLogFile = path.join(this.logDir, `debug-${dateStr}.log`);
+
+      // Get current file size if exists
+      if (fs.existsSync(this.currentLogFile)) {
+        this.currentLogSize = fs.statSync(this.currentLogFile).size;
+      } else {
+        this.currentLogSize = 0;
+      }
+
+      this.logStream = fs.createWriteStream(this.currentLogFile, { flags: 'a' });
+
+      // Clean up old log files
+      this.cleanupOldLogs();
+    }
+  }
+
+  private cleanupOldLogs(): void {
+    try {
+      const files = fs.readdirSync(this.logDir)
+        .filter(f => f.startsWith('debug-') && f.endsWith('.log'))
+        .map(f => ({
+          name: f,
+          path: path.join(this.logDir, f),
+          mtime: fs.statSync(path.join(this.logDir, f)).mtime
+        }))
+        .sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+
+      if (files.length > this.MAX_LOG_FILES) {
+        files.slice(this.MAX_LOG_FILES).forEach(f => {
+          try {
+            fs.unlinkSync(f.path);
+          } catch {
+            // Ignore deletion errors
+          }
+        });
+      }
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+
+  private rotateIfNeeded(): void {
+    if (this.currentLogSize >= this.MAX_LOG_SIZE && this.logStream) {
+      this.logStream.end();
+      this.logStream = null;
+
+      // Rename current file with timestamp
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const rotatedFile = path.join(this.logDir, `debug-${this.currentDate}-${timestamp}.log`);
+      try {
+        fs.renameSync(this.currentLogFile, rotatedFile);
+      } catch {
+        // Ignore rotation errors
+      }
+
+      this.currentLogSize = 0;
+      this.logStream = fs.createWriteStream(this.currentLogFile, { flags: 'a' });
+    }
+  }
+
+  private write(level: string, category: string, message: string, details?: Record<string, unknown>): void {
+    // Use sync initialization to avoid race conditions
+    if (!this.initPromise) {
+      this.initPromise = this.ensureLogFile();
+    }
+
+    const timestamp = this.getTimestamp();
+    const detailsStr = details ? ` ${JSON.stringify(details)}` : '';
+    const logLine = `[${timestamp}] ${level} [${category}] ${message}${detailsStr}\n`;
+
+    // Write asynchronously but don't block
+    this.initPromise.then(() => {
+      this.rotateIfNeeded();
+      if (this.logStream && !this.logStream.destroyed) {
+        this.logStream.write(logLine);
+        this.currentLogSize += Buffer.byteLength(logLine);
+      }
+    }).catch(() => {
+      // Silently fail - logging should never break the app
+    });
+  }
+
+  /**
+   * Log command execution
+   */
+  command(category: string, cmd: string, args: string[], details?: Record<string, unknown>): void {
+    const cmdStr = `${cmd} ${args.join(' ')}`.substring(0, 500);
+    this.write('CMD', category, cmdStr, details);
+  }
+
+  /**
+   * Log command result
+   */
+  result(category: string, cmd: string, exitCode: number, duration?: number): void {
+    const status = exitCode === 0 ? 'OK' : `FAIL(${exitCode})`;
+    const durationStr = duration !== undefined ? ` duration=${(duration / 1000).toFixed(2)}s` : '';
+    this.write('RES', category, `${cmd} -> ${status}${durationStr}`);
+  }
+
+  /**
+   * Log state change
+   */
+  state(category: string, action: string, details?: Record<string, unknown>): void {
+    this.write('STATE', category, action, details);
+  }
+
+  /**
+   * Log info message
+   */
+  info(category: string, message: string, details?: Record<string, unknown>): void {
+    this.write('INFO', category, message, details);
+  }
+
+  /**
+   * Log error
+   */
+  error(category: string, message: string, err?: Error): void {
+    const errDetails = err ? { error: err.message, stack: err.stack?.split('\n').slice(0, 3).join(' | ') } : undefined;
+    this.write('ERROR', category, message, errDetails);
+  }
+
+  /**
+   * Log debug info (PATH, config, etc.)
+   */
+  debug(category: string, message: string, details?: Record<string, unknown>): void {
+    this.write('DEBUG', category, message, details);
+  }
+
+  /**
+   * Close the logger
+   */
+  close(): void {
+    if (this.logStream) {
+      this.logStream.end();
+      this.logStream = null;
+    }
+  }
+}
+
+export const fileLogger = FileLogger.getInstance();


### PR DESCRIPTION
## Summary
- Add fileLogger.ts for writing debug logs to ~/.snowtree/logs/debug-*.log
- Update shellPath.ts to log PATH detection results to file
- Update cliLogger.ts to log CLI commands and results to file
- Update database.ts to log important state changes (session, folder)
- Remove verbose console.log debug statements from all modules

## Changes
This reduces console noise while preserving important debug information in log files for troubleshooting.

Log file location: `~/.snowtree/logs/debug-YYYY-MM-DD.log`

Example log format:
```
[2026-01-13 10:30:15.123] CMD [Claude] claude --verbose... {"panelId":"abc12345"}
[2026-01-13 10:30:45.456] RES [Claude] CLI process -> OK duration=30.33s
[2026-01-13 10:30:50.789] STATE [Database] Session updated: abc12345 {"status":"active"}
```