### PR TITLE
feat(ui): auto-select text on workspace rename for easier editing

### DIFF
--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -525,6 +525,14 @@ export function Sidebar() {
                                       <div className="min-w-0">
                                         {isEditing ? (
                                           <input
+                                            ref={(el) => {
+                                              if (el) {
+                                                requestAnimationFrame(() => {
+                                                  el.focus();
+                                                  el.select();
+                                                });
+                                              }
+                                            }}
                                             value={draftWorktreeName}
                                             onChange={(e) => setDraftWorktreeName(e.target.value)}
                                             onKeyDown={(e) => {
@@ -538,7 +546,6 @@ export function Sidebar() {
                                             }}
                                             onBlur={() => void commitRenameWorktree(project, worktree)}
                                             className="w-full text-[12px] font-medium rounded px-2 py-1 outline-none st-focus-ring"
-                                            autoFocus
                                             style={{
                                               backgroundColor: 'var(--st-editor)',
                                               color: 'var(--st-text)',


### PR DESCRIPTION
## Summary

When double-clicking to rename a workspace, the text in the input field is now automatically selected. This allows users to immediately start typing a new name without having to manually select and delete the existing text first.

- Uses `requestAnimationFrame` to ensure the selection happens after the input is rendered and focused

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Manual UI interaction change, tested manually

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):