### PR TITLE
feat: auto-rename git branch when worktree folder is renamed

### DIFF
--- a/packages/desktop/src/infrastructure/ipc/__tests__/sessionHandlers.test.ts
+++ b/packages/desktop/src/infrastructure/ipc/__tests__/sessionHandlers.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { IpcMain } from 'electron';
+import { registerSessionHandlers } from '../session';
+import type { AppServices } from '../types';
+
+// Mock fs module
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+}));
+
+import * as fs from 'fs';
+
+// Mock IpcMain
+class MockIpcMain {
+  private handlers: Map<string, (event: unknown, ...args: unknown[]) => unknown> = new Map();
+
+  handle(channel: string, listener: (event: unknown, ...args: unknown[]) => unknown) {
+    this.handlers.set(channel, listener);
+  }
+
+  async invoke(channel: string, ...args: unknown[]) {
+    const handler = this.handlers.get(channel);
+    if (!handler) {
+      throw new Error(`No handler registered for channel: ${channel}`);
+    }
+    return handler({}, ...args);
+  }
+
+  clear() {
+    this.handlers.clear();
+  }
+}
+
+describe('Session IPC Handlers - Worktree Path Recovery', () => {
+  let mockIpcMain: MockIpcMain;
+  let mockSessionManager: {
+    getSession: ReturnType<typeof vi.fn>;
+    getDbSession: ReturnType<typeof vi.fn>;
+    updateSession: ReturnType<typeof vi.fn>;
+    getAllSessions: ReturnType<typeof vi.fn>;
+    updateSessionStatus: ReturnType<typeof vi.fn>;
+    deleteSessionPermanently: ReturnType<typeof vi.fn>;
+    getTimelineEvents: ReturnType<typeof vi.fn>;
+    addPanelConversationMessage: ReturnType<typeof vi.fn>;
+    getPanelAgentSessionId: ReturnType<typeof vi.fn>;
+    getPanelConversationMessages: ReturnType<typeof vi.fn>;
+  };
+  let mockGitExecutor: { run: ReturnType<typeof vi.fn> };
+  let mockWorktreeManager: {
+    listWorktreesDetailed: ReturnType<typeof vi.fn>;
+    removeWorktreePath: ReturnType<typeof vi.fn>;
+  };
+  let mockDatabaseService: { getProject: ReturnType<typeof vi.fn> };
+  let mockLogger: { info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn> };
+  let mockServices: AppServices;
+
+  const sessionId = 'test-session-123';
+  const projectId = 1;
+  const oldWorktreePath = '/path/to/worktrees/paris-w7x9k2m';
+  const newWorktreePath = '/path/to/worktrees/my-feature';
+  const oldBranchName = 'paris-w7x9k2m';
+  const newBranchName = 'my-feature';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIpcMain = new MockIpcMain();
+
+    mockSessionManager = {
+      getSession: vi.fn(),
+      getDbSession: vi.fn(),
+      updateSession: vi.fn(),
+      getAllSessions: vi.fn(),
+      updateSessionStatus: vi.fn(),
+      deleteSessionPermanently: vi.fn(),
+      getTimelineEvents: vi.fn(),
+      addPanelConversationMessage: vi.fn(),
+      getPanelAgentSessionId: vi.fn(),
+      getPanelConversationMessages: vi.fn(),
+    };
+
+    mockGitExecutor = {
+      run: vi.fn(),
+    };
+
+    mockWorktreeManager = {
+      listWorktreesDetailed: vi.fn(),
+      removeWorktreePath: vi.fn(),
+    };
+
+    mockDatabaseService = {
+      getProject: vi.fn(),
+    };
+
+    mockLogger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
+
+    mockServices = {
+      sessionManager: mockSessionManager,
+      gitExecutor: mockGitExecutor,
+      worktreeManager: mockWorktreeManager,
+      databaseService: mockDatabaseService,
+      logger: mockLogger,
+      taskQueue: null,
+      gitStatusManager: { setActiveSession: vi.fn() },
+      claudeExecutor: { kill: vi.fn() },
+      codexExecutor: { kill: vi.fn() },
+      configManager: {},
+    } as unknown as AppServices;
+
+    registerSessionHandlers(mockIpcMain as unknown as IpcMain, mockServices);
+  });
+
+  describe('sessions:get with worktree path recovery', () => {
+    it('should return session directly when worktree path exists', async () => {
+      const session = {
+        id: sessionId,
+        worktreePath: oldWorktreePath,
+        projectId,
+      };
+      mockSessionManager.getSession.mockReturnValue(session);
+      (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+      const result = await mockIpcMain.invoke('sessions:get', sessionId);
+
+      expect(result).toEqual({ success: true, data: session });
+      expect(mockWorktreeManager.listWorktreesDetailed).not.toHaveBeenCalled();
+      expect(mockGitExecutor.run).not.toHaveBeenCalled();
+    });
+
+    it('should recover worktree path and rename git branch when folder is renamed', async () => {
+      const session = {
+        id: sessionId,
+        worktreePath: oldWorktreePath,
+        projectId,
+      };
+      const dbSession = {
+        worktree_name: oldBranchName,
+      };
+      const project = {
+        path: '/path/to/project',
+      };
+
+      mockSessionManager.getSession.mockReturnValue(session);
+      mockSessionManager.getDbSession.mockReturnValue(dbSession);
+      mockDatabaseService.getProject.mockReturnValue(project);
+      (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+      mockWorktreeManager.listWorktreesDetailed.mockResolvedValue([
+        { path: newWorktreePath, branch: oldBranchName },
+      ]);
+      mockGitExecutor.run.mockResolvedValue({ exitCode: 0 });
+
+      const result = await mockIpcMain.invoke('sessions:get', sessionId);
+
+      expect(result.success).toBe(true);
+      expect(mockGitExecutor.run).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId,
+          cwd: newWorktreePath,
+          argv: ['git', 'branch', '-m', oldBranchName, newBranchName],
+          op: 'write',
+        })
+      );
+      expect(mockSessionManager.updateSession).toHaveBeenCalledWith(sessionId, {
+        worktreePath: newWorktreePath,
+        worktreeName: newBranchName,
+      });
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Renamed git branch')
+      );
+    });
+
+    it('should not rename branch when folder name matches branch name', async () => {
+      const session = {
+        id: sessionId,
+        worktreePath: oldWorktreePath,
+        projectId,
+      };
+      const dbSession = {
+        worktree_name: oldBranchName,
+      };
+      const project = {
+        path: '/path/to/project',
+      };
+
+      mockSessionManager.getSession.mockReturnValue(session);
+      mockSessionManager.getDbSession.mockReturnValue(dbSession);
+      mockDatabaseService.getProject.mockReturnValue(project);
+      (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+      // Worktree found at a path with same folder name as branch
+      mockWorktreeManager.listWorktreesDetailed.mockResolvedValue([
+        { path: `/different/path/worktrees/${oldBranchName}`, branch: oldBranchName },
+      ]);
+
+      const result = await mockIpcMain.invoke('sessions:get', sessionId);
+
+      expect(result.success).toBe(true);
+      // Branch rename should NOT be called because folder name matches branch name
+      expect(mockGitExecutor.run).not.toHaveBeenCalled();
+      expect(mockSessionManager.updateSession).toHaveBeenCalledWith(sessionId, {
+        worktreePath: `/different/path/worktrees/${oldBranchName}`,
+        worktreeName: oldBranchName,
+      });
+    });
+
+    it('should return null when session has no worktreePath', async () => {
+      mockSessionManager.getSession.mockReturnValue({ id: sessionId, worktreePath: null });
+
+      const result = await mockIpcMain.invoke('sessions:get', sessionId);
+
+      // Recovery returns null but session is still returned
+      expect(result.success).toBe(true);
+    });
+
+    it('should return null when worktree not found by branch name', async () => {
+      const session = {
+        id: sessionId,
+        worktreePath: oldWorktreePath,
+        projectId,
+      };
+      const dbSession = {
+        worktree_name: oldBranchName,
+      };
+      const project = {
+        path: '/path/to/project',
+      };
+
+      mockSessionManager.getSession.mockReturnValue(session);
+      mockSessionManager.getDbSession.mockReturnValue(dbSession);
+      mockDatabaseService.getProject.mockReturnValue(project);
+      (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+      // No matching worktree found
+      mockWorktreeManager.listWorktreesDetailed.mockResolvedValue([
+        { path: '/some/other/path', branch: 'other-branch' },
+      ]);
+
+      const result = await mockIpcMain.invoke('sessions:get', sessionId);
+
+      expect(result.success).toBe(true);
+      expect(mockGitExecutor.run).not.toHaveBeenCalled();
+      expect(mockSessionManager.updateSession).not.toHaveBeenCalled();
+    });
+
+    it('should handle git branch rename failure gracefully', async () => {
+      const session = {
+        id: sessionId,
+        worktreePath: oldWorktreePath,
+        projectId,
+      };
+      const dbSession = {
+        worktree_name: oldBranchName,
+      };
+      const project = {
+        path: '/path/to/project',
+      };
+
+      mockSessionManager.getSession.mockReturnValue(session);
+      mockSessionManager.getDbSession.mockReturnValue(dbSession);
+      mockDatabaseService.getProject.mockReturnValue(project);
+      (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+      mockWorktreeManager.listWorktreesDetailed.mockResolvedValue([
+        { path: newWorktreePath, branch: oldBranchName },
+      ]);
+      // Git branch rename fails
+      mockGitExecutor.run.mockRejectedValue(new Error('Branch rename failed'));
+
+      const result = await mockIpcMain.invoke('sessions:get', sessionId);
+
+      expect(result.success).toBe(true);
+      // Session should still be updated with new path but old branch name
+      expect(mockSessionManager.updateSession).toHaveBeenCalledWith(sessionId, {
+        worktreePath: newWorktreePath,
+        worktreeName: oldBranchName,
+      });
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to rename git branch')
+      );
+    });
+
+    it('should return null when no project found', async () => {
+      const session = {
+        id: sessionId,
+        worktreePath: oldWorktreePath,
+        projectId,
+      };
+      const dbSession = {
+        worktree_name: oldBranchName,
+      };
+
+      mockSessionManager.getSession.mockReturnValue(session);
+      mockSessionManager.getDbSession.mockReturnValue(dbSession);
+      mockDatabaseService.getProject.mockReturnValue(null);
+      (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+      const result = await mockIpcMain.invoke('sessions:get', sessionId);
+
+      expect(result.success).toBe(true);
+      expect(mockWorktreeManager.listWorktreesDetailed).not.toHaveBeenCalled();
+    });
+
+    it('should return null when no worktree_name in db session', async () => {
+      const session = {
+        id: sessionId,
+        worktreePath: oldWorktreePath,
+        projectId,
+      };
+      const dbSession = {
+        worktree_name: null,
+      };
+      const project = {
+        path: '/path/to/project',
+      };
+
+      mockSessionManager.getSession.mockReturnValue(session);
+      mockSessionManager.getDbSession.mockReturnValue(dbSession);
+      mockDatabaseService.getProject.mockReturnValue(project);
+      (fs.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+      const result = await mockIpcMain.invoke('sessions:get', sessionId);
+
+      expect(result.success).toBe(true);
+      expect(mockWorktreeManager.listWorktreesDetailed).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

When a worktree folder is renamed, automatically rename the git branch to match the new folder name. This ensures the branch name displayed in the conversation panel and used for PRs reflects the renamed folder.

**Changes:**
- Add `tryRecoverWorktreePath` helper function to detect and recover renamed worktree paths
- Call recovery logic in `sessions:get` handler so branch is renamed when session is selected
- Simplify `panels:continue` to reuse the recovery function

## Tests

- [x] Unit Test

Added comprehensive unit tests in `sessionHandlers.test.ts` covering:
- Path exists: returns session directly without recovery
- Folder renamed: recovers path and renames git branch
- Folder name matches branch: updates path without renaming branch
- No worktreePath: handles gracefully
- Worktree not found: handles gracefully  
- Git rename failure: updates path with old branch name
- No project found: handles gracefully
- No worktree_name in DB: handles gracefully

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):