### PR TITLE
feat(ui): replace Open in Finder with copy path button

### DIFF
--- a/packages/ui/src/components/layout/WorkspaceHeader.tsx
+++ b/packages/ui/src/components/layout/WorkspaceHeader.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo } from 'react';
-import { GitBranch, ExternalLink } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+import { GitBranch, Copy, Check } from 'lucide-react';
 import type { WorkspaceHeaderProps } from './types';
 
 // Extract repository name from worktree path
@@ -56,9 +56,13 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = React.memo(({
     return getRepositoryName(session.worktreePath) || session.name;
   }, [session.worktreePath, session.name]);
 
-  const handleOpenInFinder = async () => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyPath = async () => {
     if (session.worktreePath) {
-      await window.electronAPI?.invoke('shell:openPath', session.worktreePath);
+      await navigator.clipboard.writeText(session.worktreePath);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
     }
   };
 
@@ -98,11 +102,15 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = React.memo(({
       <div className="flex items-center gap-1" style={{ ['WebkitAppRegion' as never]: 'no-drag' }}>
         <button
           type="button"
-          onClick={handleOpenInFinder}
+          onClick={handleCopyPath}
           className="p-1.5 rounded st-hoverable st-focus-ring"
-          title="Open in Finder"
+          title={copied ? 'Copied!' : 'Copy workspace path'}
         >
-          <ExternalLink className="w-3.5 h-3.5" style={{ color: 'var(--st-text-muted)' }} />
+          {copied ? (
+            <Check className="w-3.5 h-3.5" style={{ color: 'var(--st-success)' }} />
+          ) : (
+            <Copy className="w-3.5 h-3.5" style={{ color: 'var(--st-text-muted)' }} />
+          )}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Replace the "Open in Finder" button in WorkspaceHeader with a "Copy workspace path" button. This allows users to easily copy the workspace path to clipboard and paste it in any terminal to `cd` into the directory.

Changes:
- Replace `ExternalLink` icon with `Copy` icon (changes to `Check` icon on success)
- Use `navigator.clipboard.writeText()` to copy path
- Show visual feedback for 2 seconds after copying

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - UI change only, existing tests cover `getRepositoryName` function

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):