### PR TITLE
feat: persist plan mode (executionMode) per session

### DIFF
--- a/packages/core/src/types/panels.ts
+++ b/packages/core/src/types/panels.ts
@@ -53,6 +53,9 @@ export interface DiffPanelState {
 // Panel status type - mirrors session status but at panel level
 export type PanelStatus = 'idle' | 'running' | 'waiting' | 'stopped' | 'completed_unviewed' | 'error';
 
+// Execution mode for AI panels
+export type ExecutionMode = 'execute' | 'plan';
+
 // Base interface for AI panel states (Claude, Codex, etc.)
 export interface BaseAIPanelState {
   // Common state for all AI tools
@@ -65,6 +68,9 @@ export interface BaseAIPanelState {
   // Panel-level status tracking (independent per panel)
   panelStatus?: PanelStatus;     // Current panel execution status
   hasUnviewedContent?: boolean;  // Whether panel has content not yet viewed
+
+  // Execution mode (plan vs execute) - persisted per session
+  executionMode?: ExecutionMode; // 'execute' (default) or 'plan'
 
   // Generic agent session ID for resume functionality (used by all AI agents)
   agentSessionId?: string;        // The AI agent's session ID for resuming conversations

--- a/packages/desktop/src/infrastructure/ipc/panels.ts
+++ b/packages/desktop/src/infrastructure/ipc/panels.ts
@@ -1,6 +1,6 @@
 import type { IpcMain } from 'electron';
 import { panelManager } from '../../features/panels/PanelManager';
-import type { CreatePanelRequest } from '@snowtree/core/types/panels';
+import type { CreatePanelRequest, ToolPanel } from '@snowtree/core/types/panels';
 
 export function registerPanelHandlers(ipcMain: IpcMain): void {
   ipcMain.handle('panels:create', async (_event, request: CreatePanelRequest) => {
@@ -18,6 +18,15 @@ export function registerPanelHandlers(ipcMain: IpcMain): void {
       return { success: true, data: panels };
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : 'Failed to list panels' };
+    }
+  });
+
+  ipcMain.handle('panels:update', async (_event, panelId: string, updates: Partial<ToolPanel>) => {
+    try {
+      await panelManager.updatePanel(panelId, updates);
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Failed to update panel' };
     }
   });
 }

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -94,6 +94,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     create: (request: { sessionId: string; type: 'claude' | 'codex'; name?: string }): Promise<IPCResponse> =>
       ipcRenderer.invoke('panels:create', request),
     list: (sessionId: string): Promise<IPCResponse> => ipcRenderer.invoke('panels:list', sessionId),
+    update: (panelId: string, updates: { state?: unknown; title?: string; metadata?: unknown }): Promise<IPCResponse> =>
+      ipcRenderer.invoke('panels:update', panelId, updates),
     continue: (panelId: string, input: string, model?: string, options?: { skipCheckpointAutoCommit?: boolean; planMode?: boolean }, images?: Array<{ id: string; filename: string; mime: string; dataUrl: string }>): Promise<IPCResponse> =>
       ipcRenderer.invoke('panels:continue', panelId, input, model, options, images),
     answerQuestion: (panelId: string, panelType: 'claude' | 'codex', answers: Record<string, string | string[]>): Promise<IPCResponse> => {

--- a/packages/ui/src/components/layout/InputBar.tsx
+++ b/packages/ui/src/components/layout/InputBar.tsx
@@ -401,11 +401,31 @@ export const InputBar: React.FC<InputBarProps> = React.memo(({
   onCancel,
   isProcessing,
   placeholder = 'Message...',
-  focusRequestId
+  focusRequestId,
+  initialExecutionMode,
+  onExecutionModeChange
 }) => {
   const [isFocused, setIsFocused] = useState(false);
   const [imageAttachments, setImageAttachments] = useState<ImageAttachment[]>([]);
-  const [executionMode, setExecutionMode] = useState<ExecutionMode>('execute');
+  const [executionMode, setExecutionModeInternal] = useState<ExecutionMode>(initialExecutionMode || 'execute');
+
+  // Update local state when initialExecutionMode changes (e.g., session switch)
+  useEffect(() => {
+    if (initialExecutionMode !== undefined) {
+      setExecutionModeInternal(initialExecutionMode);
+    }
+  }, [initialExecutionMode]);
+
+  // Wrapper to notify parent when execution mode changes
+  const setExecutionMode = useCallback((mode: ExecutionMode | ((prev: ExecutionMode) => ExecutionMode)) => {
+    setExecutionModeInternal((prev) => {
+      const newMode = typeof mode === 'function' ? mode(prev) : mode;
+      if (newMode !== prev) {
+        onExecutionModeChange?.(newMode);
+      }
+      return newMode;
+    });
+  }, [onExecutionModeChange]);
   const editorRef = useRef<HTMLDivElement>(null);
   const [aiToolsStatus, setAiToolsStatus] = useState<AiToolsStatus | null>(null);
   const [, setAiToolsLoading] = useState(false);

--- a/packages/ui/src/components/layout/MainLayout.tsx
+++ b/packages/ui/src/components/layout/MainLayout.tsx
@@ -68,8 +68,10 @@ export const MainLayout: React.FC = React.memo(() => {
     isProcessing,
     isLoadingSession,
     loadError,
+    executionMode,
     reload,
     setSelectedTool,
+    setExecutionMode,
     sendMessage,
     sendMessageToTool,
     cancelRequest
@@ -427,6 +429,8 @@ export const MainLayout: React.FC = React.memo(() => {
               onCancel={cancelRequest}
               isProcessing={isProcessing}
               focusRequestId={inputFocusRequestId}
+              initialExecutionMode={executionMode}
+              onExecutionModeChange={setExecutionMode}
             />
           </>
         ) : (

--- a/packages/ui/src/components/layout/types.ts
+++ b/packages/ui/src/components/layout/types.ts
@@ -50,6 +50,8 @@ export interface InputBarProps {
   isProcessing: boolean;
   placeholder?: string;
   focusRequestId?: number;
+  initialExecutionMode?: ExecutionMode;
+  onExecutionModeChange?: (mode: ExecutionMode) => void;
 }
 
 export interface RightPanelProps {

--- a/packages/ui/src/types/electron.d.ts
+++ b/packages/ui/src/types/electron.d.ts
@@ -136,6 +136,7 @@ export interface ElectronAPI {
   panels: {
     create: (request: { sessionId: string; type: 'claude' | 'codex'; name?: string }) => Promise<IPCResponse<ToolPanel>>;
     list: (sessionId: string) => Promise<IPCResponse<ToolPanel[]>>;
+    update: (panelId: string, updates: { state?: unknown; title?: string; metadata?: unknown }) => Promise<IPCResponse<unknown>>;
     continue: (panelId: string, input: string, model?: string, options?: { skipCheckpointAutoCommit?: boolean; planMode?: boolean }, images?: Array<{ id: string; filename: string; mime: string; dataUrl: string }>) => Promise<IPCResponse<unknown>>;
     answerQuestion: (panelId: string, panelType: 'claude' | 'codex', answers: Record<string, string | string[]>) => Promise<IPCResponse<unknown>>;
   };


### PR DESCRIPTION
## Summary

Previously, the plan mode (plan vs execute) was global state - switching between sessions would not remember each session's individual mode setting. This PR makes the execution mode persist per session by storing it in the AI panel's state.

Changes:
- Add `executionMode` field to `BaseAIPanelState` in core types
- Add `panels:update` IPC handler to persist panel state changes
- Expose `panels.update` API in preload and electron types  
- Update `InputBar` to accept initial mode from props and notify parent on changes
- Update `useLayoutData` to derive mode from panel state and persist changes
- Wire `executionMode` through `MainLayout` to `InputBar`

Now when you switch between sessions, each remembers its own plan/execute mode.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Manual testing of session switching confirms mode is preserved

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):