### PR TITLE
Extract useEditorAutoFocus hook and add clean-run to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help install run dev dev-ui dev-desktop
+.PHONY: help install run dev dev-ui dev-desktop clean-run
 .PHONY: typecheck lint check test test-ui test-desktop
 .PHONY: e2e e2e-electron build ci rebuild-electron
 
@@ -9,7 +9,8 @@ help:
 	@echo ""
 	@echo "Run:"
 	@echo "  make install         Install dependencies"
-	@echo "  make run             Start dev app (UI + desktop + Electron)"
+	@echo "  make run             Start dev app (install + rebuild native deps + dev)"
+	@echo "  make clean-run       Clean start (rm node_modules + run)"
 	@echo "  make dev-ui          Start UI only (Vite)"
 	@echo "  make dev-desktop     Watch-build desktop only (tsc -w)"
 	@echo ""
@@ -37,6 +38,14 @@ lint:
 check: typecheck lint test
 
 run:
+	pnpm install
+	pnpm exec electron-builder install-app-deps
+	pnpm dev
+
+clean-run:
+	rm -rf node_modules
+	pnpm install
+	pnpm exec electron-builder install-app-deps
 	pnpm dev
 
 dev: run

--- a/packages/ui/src/components/layout/useEditorAutoFocus.ts
+++ b/packages/ui/src/components/layout/useEditorAutoFocus.ts
@@ -1,0 +1,193 @@
+import { useEffect } from 'react';
+import type React from 'react';
+
+interface UseEditorAutoFocusOptions {
+  focusRequestId: number | undefined;
+  acceptedImageTypes: readonly string[];
+  emitSelectionChange: () => void;
+  insertTextAtCursor: (text: string) => void;
+  pasteFromNavigatorClipboard: () => Promise<void>;
+  addImageAttachment: (file: File) => Promise<void>;
+}
+
+export function useEditorAutoFocus(
+  editorRef: React.RefObject<HTMLDivElement | null>,
+  {
+    focusRequestId,
+    acceptedImageTypes,
+    emitSelectionChange,
+    insertTextAtCursor,
+    pasteFromNavigatorClipboard,
+    addImageAttachment
+  }: UseEditorAutoFocusOptions
+): void {
+  useEffect(() => {
+    if (!focusRequestId) return;
+    editorRef.current?.focus();
+  }, [focusRequestId, editorRef]);
+
+  useEffect(() => {
+    editorRef.current?.focus();
+  }, [editorRef]);
+
+  useEffect(() => {
+    const focusEditor = () => {
+      const editor = editorRef.current;
+      if (!editor) return null;
+      editor.focus();
+      return editor;
+    };
+
+    const handleGlobalKeyPress = (e: KeyboardEvent) => {
+      if (document.activeElement === editorRef.current) return;
+
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'a' || e.key === 'A')) {
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        const editor = focusEditor();
+        if (!editor) return;
+        try {
+          const selection = window.getSelection();
+          if (!selection) return;
+          const range = document.createRange();
+          range.selectNodeContents(editor);
+          selection.removeAllRanges();
+          selection.addRange(range);
+          emitSelectionChange();
+        } catch {
+          // best-effort
+        }
+        return;
+      }
+
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'v' || e.key === 'V')) {
+        e.preventDefault();
+        if (!focusEditor()) return;
+        setTimeout(async () => {
+          await pasteFromNavigatorClipboard();
+        }, 0);
+        return;
+      }
+
+      if (e.key === 'Backspace' || e.key === 'Delete') {
+        e.preventDefault();
+        const editor = focusEditor();
+        if (!editor) return;
+
+        setTimeout(() => {
+          const selection = window.getSelection();
+          if (!selection || selection.rangeCount === 0) {
+            return;
+          }
+
+          const range = selection.getRangeAt(0);
+          if (!editor.contains(range.startContainer)) {
+            return;
+          }
+
+          if (!range.collapsed) {
+            range.deleteContents();
+          } else if (e.key === 'Backspace') {
+            const startContainer = range.startContainer;
+            const startOffset = range.startOffset;
+
+            if (startOffset > 0 && startContainer.nodeType === Node.TEXT_NODE) {
+              const textNode = startContainer as Text;
+              textNode.deleteData(startOffset - 1, 1);
+              range.setStart(textNode, startOffset - 1);
+              range.collapse(true);
+            }
+          } else if (e.key === 'Delete') {
+            const startContainer = range.startContainer;
+            const startOffset = range.startOffset;
+
+            if (startContainer.nodeType === Node.TEXT_NODE) {
+              const textNode = startContainer as Text;
+              if (startOffset < textNode.length) {
+                textNode.deleteData(startOffset, 1);
+              }
+            }
+          }
+
+          selection.removeAllRanges();
+          selection.addRange(range);
+          editor.dispatchEvent(new Event('input', { bubbles: true }));
+        }, 0);
+        return;
+      }
+
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      const skipKeys = [
+        'Escape', 'Tab', 'Enter',
+        'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight',
+        'Home', 'End', 'PageUp', 'PageDown',
+        'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12'
+      ];
+      if (skipKeys.includes(e.key)) return;
+
+      e.preventDefault();
+      if (!focusEditor()) return;
+      setTimeout(() => {
+        insertTextAtCursor(e.key);
+      }, 0);
+    };
+
+    const handleGlobalPasteCapture = (e: ClipboardEvent) => {
+      if (document.activeElement === editorRef.current) return;
+
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+        return;
+      }
+
+      e.preventDefault();
+      const editor = focusEditor();
+      if (!editor) return;
+
+      const clipboardData = e.clipboardData;
+      if (!clipboardData) return;
+
+      setTimeout(async () => {
+        const items = Array.from(clipboardData.items);
+        const imageItems = items.filter((item) => acceptedImageTypes.includes(item.type));
+
+        if (imageItems.length > 0) {
+          for (const item of imageItems) {
+            const file = item.getAsFile();
+            if (file) await addImageAttachment(file);
+          }
+        }
+
+        if (clipboardData.types.includes('text/plain')) {
+          const text = clipboardData.getData('text/plain');
+          if (text) insertTextAtCursor(text);
+        }
+      }, 0);
+    };
+
+    document.addEventListener('keydown', handleGlobalKeyPress, { capture: true });
+    document.addEventListener('paste', handleGlobalPasteCapture, { capture: true });
+    return () => {
+      document.removeEventListener('keydown', handleGlobalKeyPress, { capture: true });
+      document.removeEventListener('paste', handleGlobalPasteCapture, { capture: true });
+    };
+  }, [
+    editorRef,
+    acceptedImageTypes,
+    emitSelectionChange,
+    insertTextAtCursor,
+    pasteFromNavigatorClipboard,
+    addImageAttachment
+  ]);
+}


### PR DESCRIPTION
## Summary

- Extract `useEditorAutoFocus` hook from `InputBar.tsx` for better code organization
- Add `clean-run` target to Makefile for clean rebuilds when encountering dependency issues
- Update `make run` to include `electron-builder install-app-deps` for proper native module rebuilding

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Refactoring existing code and Makefile changes only

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):