### PR TITLE
Fix markdown preview for chat messages and commit diff views

### DIFF
--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -58,7 +58,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('sessions:get-diff', sessionId, target),
     getGitCommands: (sessionId: string): Promise<IPCResponse> => ipcRenderer.invoke('sessions:get-git-commands', sessionId),
     getRemotePullRequest: (sessionId: string): Promise<IPCResponse> => ipcRenderer.invoke('sessions:get-remote-pull-request', sessionId),
-    getFileContent: (sessionId: string, options: { filePath: string; ref: 'HEAD' | 'INDEX' | 'WORKTREE'; maxBytes?: number }): Promise<IPCResponse> =>
+    getFileContent: (sessionId: string, options: { filePath: string; ref: 'HEAD' | 'INDEX' | 'WORKTREE' | string; maxBytes?: number }): Promise<IPCResponse> =>
       ipcRenderer.invoke('sessions:get-file-content', sessionId, options),
     stageHunk: (sessionId: string, options: {
       filePath: string;

--- a/packages/ui/src/components/panels/timeline/InlineDiffViewer.css
+++ b/packages/ui/src/components/panels/timeline/InlineDiffViewer.css
@@ -59,6 +59,7 @@
 /* Markdown preview area */
 .inline-diff-viewer .inline-diff-preview {
   max-height: 400px;
+  overflow-y: auto;
   font-family: var(--st-font-sans, system-ui, sans-serif);
 }
 

--- a/packages/ui/src/types/electron.d.ts
+++ b/packages/ui/src/types/electron.d.ts
@@ -102,7 +102,7 @@ export interface ElectronAPI {
     getDiff: (sessionId: string, target: DiffTarget) => Promise<IPCResponse<GitDiffResultDTO>>;
     getGitCommands: (sessionId: string) => Promise<IPCResponse<{ currentBranch: string }>>;
     getRemotePullRequest: (sessionId: string) => Promise<IPCResponse<RemotePullRequestDTO | null>>;
-    getFileContent: (sessionId: string, options: { filePath: string; ref: 'HEAD' | 'INDEX' | 'WORKTREE'; maxBytes?: number }) => Promise<IPCResponse<{ content: string }>>;
+    getFileContent: (sessionId: string, options: { filePath: string; ref: 'HEAD' | 'INDEX' | 'WORKTREE' | string; maxBytes?: number }) => Promise<IPCResponse<{ content: string }>>;
     stageHunk: (sessionId: string, options: {
       filePath: string;
       isStaging: boolean;

--- a/packages/ui/src/utils/api.ts
+++ b/packages/ui/src/utils/api.ts
@@ -69,7 +69,7 @@ export class API {
       return window.electronAPI.sessions.getRemotePullRequest(sessionId);
     },
 
-    async getFileContent(sessionId: string, options: { filePath: string; ref: 'HEAD' | 'INDEX' | 'WORKTREE'; maxBytes?: number }) {
+    async getFileContent(sessionId: string, options: { filePath: string; ref: 'HEAD' | 'INDEX' | 'WORKTREE' | string; maxBytes?: number }) {
       requireElectron();
       return window.electronAPI.sessions.getFileContent(sessionId, options);
     },


### PR DESCRIPTION
## Summary

Fix two markdown preview issues:

1. **Chat message preview truncation**: Markdown preview in chat messages (InlineDiffViewer) was being cut off when content exceeded 400px because `overflow-y: auto` was missing from the `.inline-diff-preview` CSS class.

2. **Commit diff markdown preview not working**: When viewing diffs for already committed changes, the markdown preview button was not appearing because `fileSources` was always set to `null` for commit views. Extended the `getFileContent` API to accept commit refs (not just HEAD/INDEX/WORKTREE) and modified DiffOverlay to load markdown file content from the commit hash.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Manual testing of markdown preview in chat messages and commit diff views

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):