### PR TITLE
feat: display remote name in workspace header branch display

### DIFF
--- a/packages/ui/src/components/layout/MainLayout.tsx
+++ b/packages/ui/src/components/layout/MainLayout.tsx
@@ -64,6 +64,7 @@ export const MainLayout: React.FC = React.memo(() => {
     session,
     aiPanel,
     branchName,
+    remoteName,
     selectedTool,
     isProcessing,
     isLoadingSession,
@@ -442,6 +443,7 @@ export const MainLayout: React.FC = React.memo(() => {
         <WorkspaceHeader
           session={displaySession}
           branchName={branchName}
+          remoteName={remoteName}
         />
 
         {session ? (

--- a/packages/ui/src/components/layout/WorkspaceHeader.tsx
+++ b/packages/ui/src/components/layout/WorkspaceHeader.tsx
@@ -50,7 +50,8 @@ StatusDot.displayName = 'StatusDot';
 
 export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = React.memo(({
   session,
-  branchName
+  branchName,
+  remoteName
 }) => {
   const repositoryName = useMemo(() => {
     return getRepositoryName(session.worktreePath) || session.name;
@@ -95,7 +96,9 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = React.memo(({
           }}
         >
           <GitBranch className="w-3 h-3" />
-          <span className="truncate max-w-[120px]" data-testid="branch-name">{branchName || 'main'}</span>
+          <span className="truncate max-w-[180px]" data-testid="branch-name">
+            {remoteName ? `${remoteName}/${branchName || 'main'}` : branchName || 'main'}
+          </span>
         </div>
       </div>
 

--- a/packages/ui/src/components/layout/types.ts
+++ b/packages/ui/src/components/layout/types.ts
@@ -18,6 +18,7 @@ export interface FileChange {
 export interface WorkspaceHeaderProps {
   session: Session;
   branchName: string;
+  remoteName: string | null;
 }
 
 export interface PendingMessage {

--- a/packages/ui/src/components/layout/useLayoutData.test.tsx
+++ b/packages/ui/src/components/layout/useLayoutData.test.tsx
@@ -36,7 +36,7 @@ describe('useLayoutData', () => {
       success: true,
       data: { id: 's1', name: 's1', status: 'waiting', createdAt: new Date().toISOString(), toolType: 'claude' },
     });
-    (API.sessions.getGitCommands as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true, data: { currentBranch: 'main' } });
+    (API.sessions.getGitCommands as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true, data: { currentBranch: 'main', remoteName: 'origin' } });
     (API.sessions.stop as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
 
     (globalThis as unknown as { window: Window & typeof globalThis }).window.electronAPI = {

--- a/packages/ui/src/components/layout/useLayoutData.ts
+++ b/packages/ui/src/components/layout/useLayoutData.ts
@@ -9,6 +9,7 @@ interface UseLayoutDataResult {
   session: Session | null;
   aiPanel: ToolPanel | null;
   branchName: string;
+  remoteName: string | null;
   selectedTool: CLITool;
   isProcessing: boolean;
   isLoadingSession: boolean;
@@ -29,6 +30,7 @@ export function useLayoutData(sessionId: string | null): UseLayoutDataResult {
   const [aiPanel, setAiPanel] = useState<ToolPanel | null>(null);
   const aiPanelRef = useRef<ToolPanel | null>(null);
   const [branchName, setBranchName] = useState<string>('main');
+  const [remoteName, setRemoteName] = useState<string | null>(null);
   const [selectedTool, setSelectedTool] = useState<CLITool>('claude');
   const [isProcessing, setIsProcessing] = useState(false);
   const [isLoadingSession, setIsLoadingSession] = useState(false);
@@ -112,6 +114,7 @@ export function useLayoutData(sessionId: string | null): UseLayoutDataResult {
     setSession(null);
     setAiPanel(null);
     setBranchName('main');
+    setRemoteName(null);
     setLoadError(null);
     setIsProcessing(false);
     setIsLoadingSession(true);
@@ -182,8 +185,11 @@ export function useLayoutData(sessionId: string | null): UseLayoutDataResult {
         const response = await withTimeout(API.sessions.getGitCommands(sessionId), 8_000, 'Load branch');
         if (cancelled) return;
         if (response.success && response.data) {
-          const next = String(response.data.currentBranch || '').trim();
-          if (next) setBranchName((prev) => (prev === next ? prev : next));
+          const nextBranch = String(response.data.currentBranch || '').trim();
+          if (nextBranch) setBranchName((prev) => (prev === nextBranch ? prev : nextBranch));
+
+          const nextRemote = response.data.remoteName ?? null;
+          setRemoteName((prev) => (prev === nextRemote ? prev : nextRemote));
         }
       } catch {
         // best-effort; branch polling should never break the UI
@@ -358,6 +364,7 @@ export function useLayoutData(sessionId: string | null): UseLayoutDataResult {
     session,
     aiPanel,
     branchName,
+    remoteName,
     selectedTool,
     isProcessing,
     isLoadingSession,

--- a/packages/ui/src/types/electron.d.ts
+++ b/packages/ui/src/types/electron.d.ts
@@ -100,7 +100,7 @@ export interface ElectronAPI {
     getTimeline: (sessionId: string) => Promise<IPCResponse<TimelineEvent[]>>;
     getExecutions: (sessionId: string) => Promise<IPCResponse<ExecutionDTO[]>>;
     getDiff: (sessionId: string, target: DiffTarget) => Promise<IPCResponse<GitDiffResultDTO>>;
-    getGitCommands: (sessionId: string) => Promise<IPCResponse<{ currentBranch: string }>>;
+    getGitCommands: (sessionId: string) => Promise<IPCResponse<{ currentBranch: string; remoteName: string | null }>>;
     getRemotePullRequest: (sessionId: string) => Promise<IPCResponse<RemotePullRequestDTO | null>>;
     getFileContent: (sessionId: string, options: { filePath: string; ref: 'HEAD' | 'INDEX' | 'WORKTREE'; maxBytes?: number }) => Promise<IPCResponse<{ content: string }>>;
     stageHunk: (sessionId: string, options: {


### PR DESCRIPTION
## Summary

Display the tracking remote name alongside the branch name in the workspace header. When a branch has a tracking remote configured (e.g., `origin`), the header now shows `origin/branch-name` instead of just `branch-name`.

**Changes:**
- Modified `git.ts` to fetch the tracking remote using `git rev-parse --abbrev-ref --symbolic-full-name @{upstream}`
- Added `remoteName` field to the IPC response and TypeScript types
- Updated `useLayoutData` hook to poll and manage `remoteName` state
- Updated `WorkspaceHeader` component to display `remoteName/branchName` format when remote is available

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):