### PR TITLE
Add Databend credits across UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     ]
   },
   "scripts": {
+    "predev": "pnpm --filter @snowtree/core build",
     "dev": "concurrently \"pnpm --filter @snowtree/desktop dev\" \"pnpm --filter @snowtree/ui dev\" \"wait-on http://localhost:4521 && node tools/scripts/run-electron-dev.mjs\"",
     "build": "pnpm --filter @snowtree/core build && pnpm --filter @snowtree/desktop build && pnpm --filter @snowtree/ui build && pnpm run build:electron",
     "build:desktop": "pnpm --filter @snowtree/desktop build",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -8,7 +8,7 @@
     "@snowtree/core": "workspace:*"
   },
   "scripts": {
-    "dev": "tsc -w",
+    "dev": "npm run copy:assets && tsc -w",
     "build": "rimraf dist && tsc && npm run copy:assets",
     "copy:assets": "mkdirp dist/infrastructure/database/migrations dist/windows dist/assets && cp src/infrastructure/database/*.sql dist/infrastructure/database/ && cp src/infrastructure/database/migrations/*.sql dist/infrastructure/database/migrations/ && cp src/windows/*.html dist/windows/ && cp assets/snowtree-logo.png dist/assets/",
     "lint": "eslint src --ext .ts",

--- a/packages/desktop/src/windows/about.html
+++ b/packages/desktop/src/windows/about.html
@@ -68,6 +68,15 @@
       letter-spacing: 0.2px;
     }
 
+    .credits {
+      font-size: 14px;
+      font-weight: 400;
+      color: #a0a0a0;
+      letter-spacing: 0.3px;
+      text-transform: uppercase;
+      margin-top: -2px;
+    }
+
     .copyright {
       font-size: 13px;
       color: #606060;
@@ -124,13 +133,14 @@
     </div>
 
     <div class="app-name">snowtree</div>
-    <div class="copyright">© 2026 BohuTANG</div>
+    <div class="credits">Made by Databend Team</div>
+    <div class="copyright">© 2026 Databend Labs</div>
 
-    <a class="github-link" id="github-link" href="https://github.com/bohutang/snowtree">
+    <a class="github-link" id="github-link" href="https://github.com/databendlabs/snowtree">
       <svg class="github-icon" viewBox="0 0 16 16">
         <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
       </svg>
-      <span>github.com/bohutang/snowtree</span>
+      <span>github.com/databendlabs/snowtree</span>
     </a>
   </div>
 
@@ -138,7 +148,7 @@
     // Handle link clicks
     document.getElementById('github-link').addEventListener('click', (e) => {
       e.preventDefault();
-      window.electron.openExternal('https://github.com/bohutang/snowtree');
+      window.electron.openExternal('https://github.com/databendlabs/snowtree');
     });
   </script>
 </body>

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -222,6 +222,14 @@ export function Sidebar() {
     }
   }, [appVersion]);
 
+  const handleOpenDatabend = useCallback(async () => {
+    try {
+      await window.electronAPI?.invoke?.('shell:openExternal', 'https://github.com/databendlabs/databend');
+    } catch {
+      // ignore
+    }
+  }, []);
+
 
   const handleAddRepository = useCallback(async () => {
     try {
@@ -831,6 +839,17 @@ export function Sidebar() {
             )}
           </button>
         </div>
+        <button
+          type="button"
+          onClick={handleOpenDatabend}
+          className="text-[10px] px-2 py-1 rounded transition-colors st-hoverable st-focus-ring flex items-center gap-1 whitespace-nowrap overflow-hidden"
+          style={{ color: 'var(--st-text-muted)' }}
+          title="Open Databend Labs on GitHub"
+        >
+          <span className="truncate text-left">
+            Made by Databend Team · <span style={{ color: 'var(--st-text-faint)' }}>github.com/databendlabs/databend</span>
+          </span>
+        </button>
         {updateError && (
           <div className="text-[10px] leading-snug" style={{ color: 'var(--st-text-muted)' }}>
             {updateError}


### PR DESCRIPTION
## Summary

- add Databend team attribution to the sidebar footer and about window, linking to the Databend Snowtree repo
- update the about dialog copyright to Databend Labs and keep the GitHub link consistent
- rebuild @snowtree/core before dev so the desktop watcher always sees the generated dist artifacts

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - UI-only branding/link adjustments

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
