### PR TITLE
Align file change list empty states to leading edge

### DIFF
--- a/packages/ui/src/components/layout/RightPanel/FileChangeList.tsx
+++ b/packages/ui/src/components/layout/RightPanel/FileChangeList.tsx
@@ -64,7 +64,7 @@ export const FileChangeList: React.FC<FileChangeListProps> = React.memo(
     if (showLoading) {
       return (
         <div
-          className="flex flex-col items-center justify-center py-8 gap-2"
+          className="flex flex-col items-start py-8 px-3 gap-2"
           style={{ color: colors.text.muted }}
         >
           <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
@@ -81,7 +81,7 @@ export const FileChangeList: React.FC<FileChangeListProps> = React.memo(
 
     if (error && !isIgnorableError) {
       return (
-        <div className="flex flex-col items-center justify-center py-6 gap-2">
+        <div className="flex flex-col items-start py-6 px-3 gap-2">
           <span className="text-xs" style={{ color: colors.text.deleted }}>
             {error}
           </span>
@@ -111,7 +111,7 @@ export const FileChangeList: React.FC<FileChangeListProps> = React.memo(
       if (isEmpty) {
         return (
           <div
-            className="flex items-center justify-center py-8 text-xs"
+            className="flex items-start py-8 px-3 text-xs"
             style={{ color: colors.text.muted }}
           >
             {!hasSelection ? 'Select a commit' : 'Working tree clean'}
@@ -206,7 +206,7 @@ export const FileChangeList: React.FC<FileChangeListProps> = React.memo(
     if (commitFiles.length === 0) {
       return (
         <div
-          className="flex items-center justify-center py-8 text-xs"
+          className="flex items-start py-8 px-3 text-xs"
           style={{ color: colors.text.muted }}
         >
           {!hasSelection ? 'Select a commit' : 'No changes'}


### PR DESCRIPTION
## Summary

Aligns all empty state containers in the file change list to the leading edge instead of center alignment.

Changes the alignment of loading, error, empty working tree, and "no changes" states from `items-center justify-center` to `items-start` with `px-3` padding to match the indentation of the file list items.

## Tests

- [x] No Test - UI alignment fix, verified visually

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): UI alignment improvement