### PR TITLE
Align file list items to leading edge

### DIFF
--- a/packages/ui/src/components/layout/RightPanel/FileItem.tsx
+++ b/packages/ui/src/components/layout/RightPanel/FileItem.tsx
@@ -20,7 +20,7 @@ export const FileItem: React.FC<FileItemProps> = React.memo(
         onClick={onClick}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
-        className="w-full flex items-center justify-between px-3 py-1.5 text-xs transition-colors duration-75"
+        className="w-full flex items-center justify-start gap-2 px-3 py-1.5 text-xs transition-colors duration-75"
         style={{
           backgroundColor: bg,
           borderLeft: isSelected
@@ -28,27 +28,25 @@ export const FileItem: React.FC<FileItemProps> = React.memo(
             : '2px solid transparent',
         }}
       >
-        <div className="flex items-center gap-2 min-w-0 flex-1">
-          <span
-            className="font-mono text-[10px] font-semibold px-1 rounded"
-            style={{ color: typeInfo.color, backgroundColor: typeInfo.bg }}
-          >
-            {typeInfo.label}
-          </span>
-          <span
-            className="truncate"
-            style={{
-              color:
-                isSelected || isHovered
-                  ? colors.text.primary
-                  : colors.text.secondary,
-            }}
-          >
-            {file.path}
-          </span>
-        </div>
+        <span
+          className="font-mono text-[10px] font-semibold px-1 rounded flex-shrink-0"
+          style={{ color: typeInfo.color, backgroundColor: typeInfo.bg }}
+        >
+          {typeInfo.label}
+        </span>
+        <span
+          className="truncate min-w-0 flex-1 text-left"
+          style={{
+            color:
+              isSelected || isHovered
+                ? colors.text.primary
+                : colors.text.secondary,
+          }}
+        >
+          {file.path}
+        </span>
         {!hideStats && (
-          <div className="flex items-center gap-1.5 text-[10px] flex-shrink-0 ml-2 font-mono">
+          <div className="flex items-center gap-1.5 text-[10px] flex-shrink-0 font-mono">
             {file.additions > 0 && (
               <span style={{ color: colors.text.added }}>+{file.additions}</span>
             )}

--- a/packages/ui/src/components/layout/RightPanel/WorkingFileRow.tsx
+++ b/packages/ui/src/components/layout/RightPanel/WorkingFileRow.tsx
@@ -21,7 +21,7 @@ export const WorkingFileRow: React.FC<WorkingFileRowProps> = React.memo(
         onClick={onClick}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
-        className="w-full flex items-center gap-2 px-3 py-1.5 text-xs transition-colors duration-75"
+        className="w-full flex items-center justify-start gap-2 px-3 py-1.5 text-xs transition-colors duration-75"
         style={{
           backgroundColor: bg,
           borderLeft: isSelected
@@ -43,7 +43,7 @@ export const WorkingFileRow: React.FC<WorkingFileRowProps> = React.memo(
           {typeInfo.label}
         </span>
         <span
-          className="truncate min-w-0 flex-1"
+          className="truncate min-w-0 flex-1 text-left"
           style={{
             color:
               isSelected || isHovered


### PR DESCRIPTION
## Summary

Fixed the alignment of file list items in the right panel changes view. Previously, file names appeared centered when the file name was short. Now all file list items align to the leading edge (left side) consistently.

Changes:
- Modified `FileItem.tsx` to use `justify-start` and removed the nested flex container that caused centering
- Modified `WorkingFileRow.tsx` to use `justify-start` for consistent left alignment
- Added `flex-1` and `text-left` to file name spans to ensure text starts from the left

## Tests

- [x] No Test - UI alignment fix, verified visually

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [x] Other (please describe): UI alignment improvement