### PR TITLE
Persist session tool settings

### DIFF
--- a/packages/desktop/src/features/session/SessionManager.ts
+++ b/packages/desktop/src/features/session/SessionManager.ts
@@ -349,6 +349,8 @@ export class SessionManager extends EventEmitter {
       : toolTypeFromDb === 'none'
         ? 'none'
         : 'claude';
+    const executionModeFromDb = (dbSession as DbSession & { execution_mode?: 'plan' | 'execute' | null }).execution_mode;
+    const normalizedExecutionMode: 'plan' | 'execute' = executionModeFromDb === 'plan' ? 'plan' : 'execute';
 
     const mappedStatus = this.mapDbStatusToSessionStatus(dbSession.status, dbSession.last_viewed_at || undefined, dbSession.updated_at);
 
@@ -386,6 +388,7 @@ export class SessionManager extends EventEmitter {
       commitModeSettings: dbSession.commit_mode_settings || undefined,
       skipContinueNext: dbSession.skip_continue_next || undefined,
       claudeSessionId: dbSession.claude_session_id || undefined,
+      executionMode: normalizedExecutionMode,
     };
   }
 
@@ -826,7 +829,13 @@ export class SessionManager extends EventEmitter {
       dbUpdate.base_branch = update.baseBranch;
     }
 
-    // Model is now managed at panel level, not session level
+    if (update.toolType !== undefined) {
+      dbUpdate.tool_type = update.toolType;
+    }
+
+    if (update.executionMode !== undefined) {
+      dbUpdate.execution_mode = update.executionMode;
+    }
 
     if (update.skipContinueNext !== undefined) {
       dbUpdate.skip_continue_next = update.skipContinueNext;

--- a/packages/desktop/src/features/session/__tests__/SessionManager.test.ts
+++ b/packages/desktop/src/features/session/__tests__/SessionManager.test.ts
@@ -189,6 +189,29 @@ describe('SessionManager', () => {
       await sessionManager.updateSession(session.id, { status: 'completed' });
       expect(sessionManager.getSession(session.id).isRunning).toBe(false);
     });
+
+    it('should persist toolType and executionMode changes', async () => {
+      const session = await sessionManager.createSession({
+        name: 'Test',
+        worktreePath: '/tmp/test',
+        prompt: 'Test',
+        toolType: 'claude',
+      });
+
+      await sessionManager.updateSession(session.id, { toolType: 'codex', executionMode: 'plan' });
+
+      const reloadedManager = new SessionManager(mockDb);
+      const updated = reloadedManager.getSession(session.id);
+
+      expect(updated.toolType).toBe('codex');
+      expect(updated.executionMode).toBe('plan');
+
+      await reloadedManager.updateSession(session.id, { status: 'running' });
+      const afterStatusUpdate = reloadedManager.getSession(session.id);
+
+      expect(afterStatusUpdate.toolType).toBe('codex');
+      expect(afterStatusUpdate.executionMode).toBe('plan');
+    });
   });
 
   describe('getAllSessions', () => {

--- a/packages/desktop/src/infrastructure/database/database.ts
+++ b/packages/desktop/src/infrastructure/database/database.ts
@@ -842,6 +842,10 @@ export class DatabaseService {
       updates.push('auto_commit = ?');
       values.push(data.auto_commit ? 1 : 0);
     }
+    if (data.tool_type !== undefined) {
+      updates.push('tool_type = ?');
+      values.push(data.tool_type);
+    }
     if (data.skip_continue_next !== undefined) {
       updates.push('skip_continue_next = ?');
       values.push(data.skip_continue_next ? 1 : 0);
@@ -857,6 +861,10 @@ export class DatabaseService {
     if (data.archived !== undefined) {
       updates.push('archived = ?');
       values.push(data.archived ? 1 : 0);
+    }
+    if (data.execution_mode !== undefined) {
+      updates.push('execution_mode = ?');
+      values.push(data.execution_mode);
     }
 
     if (updates.length === 0) {

--- a/packages/desktop/src/infrastructure/database/models.ts
+++ b/packages/desktop/src/infrastructure/database/models.ts
@@ -117,6 +117,7 @@ export interface UpdateSessionData {
   run_started_at?: string;
   is_favorite?: boolean;
   auto_commit?: boolean;
+  tool_type?: 'claude' | 'codex' | 'none';
   commit_mode?: 'structured' | 'checkpoint' | 'disabled';
   commit_mode_settings?: string; // JSON string of CommitModeSettings
   skip_continue_next?: boolean;
@@ -125,6 +126,7 @@ export interface UpdateSessionData {
   base_commit?: string | null;
   base_branch?: string | null;
   archived?: boolean;
+  execution_mode?: 'plan' | 'execute';
 }
 
 export interface PromptMarker {


### PR DESCRIPTION
## Summary

This PR adds persistence for session tool settings, ensuring that tool configurations are maintained across sessions.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - UI/configuration change, manually verified

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):