### PR TITLE
Ignore non printable keys in editor

### DIFF
--- a/packages/ui/src/components/layout/useEditorAutoFocus.ts
+++ b/packages/ui/src/components/layout/useEditorAutoFocus.ts
@@ -136,6 +136,9 @@ export function useEditorAutoFocus(
       ];
       if (skipKeys.includes(e.key)) return;
 
+      // Only insert printable single characters
+      if (e.key.length !== 1) return;
+
       e.preventDefault();
       if (!focusEditor()) return;
       setTimeout(() => {


### PR DESCRIPTION
## Summary
- ensure the global key handler only inserts printable single characters when seizing focus
- prevents function/media/IME keys from inserting their labels when the editor auto-focuses text input

## Tests
- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Relied on manual verification of keypress behavior in the editor_

## Type of change
- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
