### PR TITLE
Fix agent session ID isolation and persistence timing

### DIFF
--- a/packages/desktop/src/features/panels/base/AbstractAIPanelManager.ts
+++ b/packages/desktop/src/features/panels/base/AbstractAIPanelManager.ts
@@ -60,8 +60,8 @@ export abstract class AbstractAIPanelManager {
         agentCwd: pending.agentCwd,
       });
       this.pendingAgentSessionIds.delete(panelId);
-    } catch (err) {
-      this.logger?.error(`[${this.getAgentName()}PanelManager] Failed to persist session ID:`, err);
+    } catch {
+      // best-effort persistence
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes two critical issues with agent session ID management when switching between Codex and Claude:

1. **Session ID isolation bug**: When switching tools (Codex ↔ Claude), session IDs were incorrectly shared, causing 'No conversation found' errors
2. **Persistence timing bug**: Session IDs were persisted immediately upon CLI init, even if the CLI crashed before successfully saving the session

### Changes

**Session ID Isolation (SessionManager.ts)**
- Modified `getPanelAgentSessionId()` to prioritize tool-specific fields (`claudeSessionId`, `codexSessionId`) over the generic `agentSessionId` field
- Simplified `getPanelClaudeSessionId()` and `getPanelCodexSessionId()` to use only their specific fields
- Prevents cross-contamination when switching between tools

**Session ID Persistence Timing (AbstractAIPanelManager.ts)**
- Added pending session ID cache to delay persistence until confirmation
- Session IDs are now only persisted after receiving the first assistant message, confirming CLI has successfully saved the session
- Unconfirmed session IDs are discarded if the process exits early
- Prevents saving session IDs that the CLI never persisted

## Tests

- [ ] No Test - Manual testing required for session switching scenarios

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [x] Refactoring