### PR TITLE
fix(codex): don't override model, let codex use its own config default

### DIFF
--- a/packages/core/src/types/models.ts
+++ b/packages/core/src/types/models.ts
@@ -3,10 +3,10 @@
  * These models became available after GPT-5's release on August 7, 2025
  */
 
-export type OpenAICodexModel = 
+export type OpenAICodexModel =
   | 'auto'
   | 'gpt-5'
-  | 'gpt-5-codex';
+  | 'gpt-5.2-codex';
 
 export interface CodexModelConfig {
   id: OpenAICodexModel;
@@ -25,10 +25,10 @@ export const CODEX_MODELS: Record<OpenAICodexModel, CodexModelConfig> = {
     label: 'GPT-5',
     description: 'Standard GPT-5 model for general use'
   },
-  'gpt-5-codex': {
-    id: 'gpt-5-codex',
-    label: 'GPT-5 Codex',
-    description: 'GPT-5 optimized for coding tasks'
+  'gpt-5.2-codex': {
+    id: 'gpt-5.2-codex',
+    label: 'GPT-5.2 Codex',
+    description: 'GPT-5.2 optimized for coding tasks'
   }
 };
 
@@ -43,7 +43,7 @@ export function getCodexModelList(): CodexModelConfig[] {
 }
 
 // Default model if none specified
-export const DEFAULT_CODEX_MODEL: OpenAICodexModel = 'gpt-5-codex';
+export const DEFAULT_CODEX_MODEL: OpenAICodexModel = 'auto';
 
 // Codex input options interface
 export interface CodexInputOptions {

--- a/packages/desktop/src/executors/codex/CodexExecutor.ts
+++ b/packages/desktop/src/executors/codex/CodexExecutor.ts
@@ -971,12 +971,12 @@ export class CodexExecutor extends AbstractExecutor {
     // Plan mode - use read-only sandbox to prevent code modifications
     const sandbox = options.planMode ? 'read-only' : codexOptions.sandbox;
 
-    const overrides = {
+    const overrides: Record<string, unknown> = {
       cwd: worktreePath,
-      model: codexOptions.model,
       sandbox,
       approvalPolicy: codexOptions.askForApproval,
     };
+    // Don't pass model - let codex use its own config default (like Claude CLI)
 
     // Create or resume conversation
     const convo = isResume && resumePath


### PR DESCRIPTION
## Summary

Don't pass model parameter to codex, let it use its own config default from `~/.codex/config.toml` (similar to how Claude CLI works).

Changes:
- Remove model parameter from `newConversation` call in CodexExecutor
- Update default model to `auto` and add `gpt-5.2-codex` option in models.ts

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - Manual testing only, behavior change is straightforward

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):