### PR TITLE
fix(ui): disable block caret blinking animation

### DIFF
--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -792,7 +792,8 @@ body {
   height: 1em;
   border-radius: 1px;
   background: currentColor;
-  animation: st-block-caret-blink var(--st-caret-blink, 1s) step-start infinite;
+  animation: none;
+  opacity: 0.7;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary

Disable block caret blinking animation and use static opacity instead for a cleaner visual experience.

- Replace animation with static `opacity: 0.7`
- Removes distracting blink effect from block caret

## Tests

- [x] No Test - Visual/CSS only change, no functional logic affected

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)