### PR TITLE
fix(panels): preserve agentSessionId when answering user questions

### DIFF
--- a/packages/desktop/src/features/panels/base/AbstractAIPanelManager.ts
+++ b/packages/desktop/src/features/panels/base/AbstractAIPanelManager.ts
@@ -75,7 +75,7 @@ export abstract class AbstractAIPanelManager {
     this.logger?.verbose(`[${this.getAgentName()}PanelManager] Discarding unconfirmed session ID for panel ${panelId}: ${pending.agentSessionId}`);
     this.pendingAgentSessionIds.delete(panelId);
 
-    // Clear from in-memory mapping
+    // Clear from in-memory mapping since it was never confirmed
     const mapping = this.panelMappings.get(panelId);
     if (mapping) {
       mapping.agentSessionId = undefined;
@@ -111,7 +111,8 @@ export abstract class AbstractAIPanelManager {
       // Confirm session ID on first assistant message (CLI has persisted successfully)
       if (data.type === 'json' && typeof data.data === 'object' && data.data !== null) {
         const jsonData = data.data as { type?: string };
-        if (jsonData.type === 'assistant') {
+        // Confirm on assistant message OR result message (both indicate successful CLI execution)
+        if (jsonData.type === 'assistant' || jsonData.type === 'result') {
           this.confirmAndPersistSessionId(panelId);
         }
       }

--- a/packages/desktop/src/infrastructure/ipc/session.ts
+++ b/packages/desktop/src/infrastructure/ipc/session.ts
@@ -330,8 +330,15 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
       }
 
       const manager = ensureClaudePanelManager();
-      // Register panel if not already registered
-      manager.registerPanel(panelId, session.id, panel.state?.customState as AIPanelState | undefined, false);
+      // Only register if not already registered (to preserve agentSessionId in memory)
+      if (!manager.getPanelState(panelId)) {
+        manager.registerPanel(panelId, session.id, panel.state?.customState as AIPanelState | undefined, false);
+        // Hydrate agentSessionId from database after registration
+        const agentSessionId = sessionManager.getPanelAgentSessionId(panelId);
+        if (agentSessionId) {
+          manager.setAgentSessionId(panelId, agentSessionId);
+        }
+      }
 
       await manager.answerQuestion(panelId, answers);
       return { success: true };
@@ -357,8 +364,15 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
       }
 
       const manager = ensureCodexPanelManager();
-      // Register panel if not already registered
-      manager.registerPanel(panelId, session.id, panel.state?.customState as AIPanelState | undefined, false);
+      // Only register if not already registered (to preserve agentSessionId in memory)
+      if (!manager.getPanelState(panelId)) {
+        manager.registerPanel(panelId, session.id, panel.state?.customState as AIPanelState | undefined, false);
+        // Hydrate agentSessionId from database after registration
+        const agentSessionId = sessionManager.getPanelAgentSessionId(panelId);
+        if (agentSessionId) {
+          manager.setAgentSessionId(panelId, agentSessionId);
+        }
+      }
 
       await manager.answerQuestion(panelId, answers);
       return { success: true };


### PR DESCRIPTION
## Summary

Fix the issue where `--resume` flag was not being used when answering user questions from the `AskUserQuestion` tool.

**Root cause**: The `answer-question` IPC handlers in `session.ts` were unconditionally calling `registerPanel()`, which created a new mapping object and lost the in-memory `agentSessionId`.

**Changes**:
- Only register panel if not already registered (to preserve agentSessionId in memory)
- Hydrate agentSessionId from database after registration if needed
- Confirm session ID on `result` message in addition to `assistant` message
- Add agentSessionId hydration in `registerExistingPanels` for app restart scenarios

## Tests

- [x] No Test - Manual testing confirmed the fix works correctly

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)