### PR TITLE
fix: correct GitHub release repo from bohutang to databendlabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "description": "Snowtree - Review-Driven Safe AI Coding",
-  "homepage": "https://github.com/bohutang/snowtree",
+  "homepage": "https://github.com/databendlabs/snowtree",
   "author": {
     "name": "Snowtree",
     "email": "overred.shuttler@gmail.com"
@@ -87,7 +87,7 @@
     "publish": [
       {
         "provider": "github",
-        "owner": "bohutang",
+        "owner": "databendlabs",
         "repo": "snowtree",
         "releaseType": "release"
       }


### PR DESCRIPTION
## Summary

Fix CI release workflow failure by correcting the electron-builder publish configuration.

The publish step was failing with `403 Forbidden` because it was trying to create a release on `bohutang/snowtree` (a fork) instead of `databendlabs/snowtree` (the org repo). The GitHub Actions token only has permissions for the org repo.

Changes:
- Updated `homepage` in package.json from `bohutang/snowtree` to `databendlabs/snowtree`
- Updated electron-builder `publish.owner` from `bohutang` to `databendlabs`

## Tests

- [ ] No Test - Configuration change only, will be validated by CI release workflow

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)