### PR TITLE
fix: update macOS DMG download URL to databendlabs repo

### DIFF
--- a/packages/desktop/src/features/updater/UpdateManager.ts
+++ b/packages/desktop/src/features/updater/UpdateManager.ts
@@ -120,7 +120,7 @@ export class UpdateManager extends EventEmitter {
     const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
     const version = this.latestVersion;
     const dmgName = `snowtree-${version}-macOS-${arch}.dmg`;
-    const downloadUrl = `https://github.com/bohutang/snowtree/releases/download/v${version}/${dmgName}`;
+    const downloadUrl = `https://github.com/databendlabs/snowtree/releases/download/v${version}/${dmgName}`;
     const tmpDir = os.tmpdir();
     const dmgPath = path.join(tmpDir, dmgName);
 


### PR DESCRIPTION
## Summary

Fix macOS auto-update download URL in `UpdateManager.ts`.

The hardcoded download URL was pointing to `bohutang/snowtree` instead of `databendlabs/snowtree`, which would cause macOS DMG downloads to fail after the release repo was changed.

## Tests

- [ ] No Test - URL change only, will be validated by actual update flow

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)