### PR TITLE
Add ExitPlanMode tool support with auto mode switching

### DIFF
--- a/packages/desktop/src/executors/claude/ClaudeExecutor.ts
+++ b/packages/desktop/src/executors/claude/ClaudeExecutor.ts
@@ -444,6 +444,22 @@ export class ClaudeExecutor extends AbstractExecutor {
           continue; // Skip regular tool_use handling
         }
 
+        // Special handling for ExitPlanMode - switch execution mode to 'execute'
+        if (toolName === 'ExitPlanMode') {
+          cliLogger.info('Claude', panelId, 'ExitPlanMode tool called - switching to execute mode');
+
+          // Switch the session's execution mode from 'plan' to 'execute'
+          try {
+            this.sessionManager.updateSession(sessionId, { executionMode: 'execute' });
+          } catch (error) {
+            const err = error instanceof Error ? error : new Error(String(error));
+            this.logger?.error(`Failed to switch execution mode for session ${sessionId}:`, err);
+          }
+
+          // Continue to emit the tool_use entry for timeline display
+          // (Don't skip regular handling - we want to show it in the timeline)
+        }
+
         // Regular tool_use handling for other tools
         // Create and emit tool_use entry using the message parser
         const toolUseMessage = {

--- a/packages/ui/src/components/panels/timeline/ToolCallMessage.tsx
+++ b/packages/ui/src/components/panels/timeline/ToolCallMessage.tsx
@@ -72,6 +72,7 @@ export const getToolIcon = (toolName: string, toolInput?: string | Record<string
     case 'write': return FileInput;
     case 'webfetch':
     case 'websearch': return Globe;
+    case 'exitplanmode': return ArrowRight;
     default: return Wrench;
   }
 };


### PR DESCRIPTION
## Summary

Add support for the ExitPlanMode tool call, which allows Claude to automatically exit plan mode and switch to execute mode.

When Claude is running in plan mode and calls the ExitPlanMode tool:
- The timeline displays the tool call with an arrow icon (→)
- The backend automatically updates the session's execution mode from 'plan' to 'execute'
- The change is persisted to the database
- Subsequent operations run in execute mode

Changes:
- Added ExitPlanMode icon to timeline UI (ToolCallMessage.tsx)
- Implemented execution mode switching logic in ClaudeExecutor
- Tool call is displayed in timeline for visibility

## Tests

- [x] No Test - This is a UI enhancement and mode switching feature that integrates with existing session management. Manual testing required to verify:
  - ExitPlanMode icon appears in timeline
  - Session mode switches from plan to execute when tool is called
  - Mode change persists in database

## Type of change

- [x] New Feature (non-breaking change which adds functionality)