### PR TITLE
Add auto-delete branch on worktree remove

### DIFF
--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -37,8 +37,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     delete: (projectId: number): Promise<IPCResponse> => ipcRenderer.invoke('projects:delete', projectId),
     getWorktrees: (projectId: number, sessionId?: string | null): Promise<IPCResponse> =>
       ipcRenderer.invoke('projects:get-worktrees', projectId, sessionId),
-    removeWorktree: (projectId: number, worktreePath: string, sessionId?: string | null): Promise<IPCResponse> =>
-      ipcRenderer.invoke('projects:remove-worktree', projectId, worktreePath, sessionId),
+    removeWorktree: (projectId: number, worktreePath: string, sessionId?: string | null, autoDeleteBranch?: boolean): Promise<IPCResponse> =>
+      ipcRenderer.invoke('projects:remove-worktree', projectId, worktreePath, sessionId, autoDeleteBranch),
     renameWorktree: (projectId: number, worktreePath: string, nextName: string, sessionId?: string | null): Promise<IPCResponse> =>
       ipcRenderer.invoke('projects:rename-worktree', projectId, worktreePath, nextName, sessionId),
   },

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -266,6 +266,38 @@ export function SettingsDialog() {
               </div>
             </div>
           </section>
+
+          {/* Worktree Settings */}
+          <section className="space-y-3">
+            <h3 className="text-sm font-semibold" style={{ color: 'var(--st-text)' }}>
+              Worktree Settings
+            </h3>
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <label className="text-sm" style={{ color: 'var(--st-text-muted)' }}>
+                  Auto-delete branch on worktree remove
+                </label>
+                <button
+                  type="button"
+                  onClick={() => updateSettings({
+                    autoDeleteBranchOnWorktreeRemove: !settings.autoDeleteBranchOnWorktreeRemove
+                  })}
+                  className="flex-shrink-0 w-10 h-5 cursor-pointer rounded-full p-0.5"
+                  role="switch"
+                  aria-checked={settings.autoDeleteBranchOnWorktreeRemove}
+                  style={{
+                    backgroundColor: settings.autoDeleteBranchOnWorktreeRemove ? 'var(--st-accent)' : 'var(--st-border)',
+                    transition: 'background-color 0.2s'
+                  }}
+                >
+                  <span
+                    className="block h-4 w-4 bg-white rounded-full transition-transform"
+                    style={{ transform: settings.autoDeleteBranchOnWorktreeRemove ? 'translateX(1.25rem)' : 'translateX(0)' }}
+                  />
+                </button>
+              </div>
+            </div>
+          </section>
         </div>
 
         {/* Footer */}

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -46,7 +46,7 @@ const applyBaseCommitSuffix = (name: string, baseCommit?: string): string => {
 export function Sidebar() {
   const { showError } = useErrorStore();
   const { sessions, activeSessionId, setActiveSession } = useSessionStore();
-  const { openSettings } = useSettingsStore();
+  const { openSettings, settings } = useSettingsStore();
   const [projects, setProjects] = useState<Project[]>([]);
   const [activeProjectId, setActiveProjectId] = useState<number | null>(null);
   const [collapsedProjects, setCollapsedProjects] = useState<Set<number>>(() => new Set());
@@ -291,7 +291,7 @@ export function Sidebar() {
         ...prev,
         [project.id]: (prev[project.id] || []).filter((w) => w.path !== worktree.path),
       }));
-      const res = await API.projects.removeWorktree(project.id, worktree.path, activeSessionId);
+      const res = await API.projects.removeWorktree(project.id, worktree.path, activeSessionId, settings.autoDeleteBranchOnWorktreeRemove);
       if (!res.success) {
         showError({ title: 'Failed to Delete Workspace', error: res.error || 'Could not delete worktree' });
         void loadWorktrees(project, { silent: true });
@@ -301,7 +301,7 @@ export function Sidebar() {
     } catch (error) {
       showError({ title: 'Failed to Delete Workspace', error: error instanceof Error ? error.message : 'Unknown error' });
     }
-  }, [showError, loadWorktrees, activeSessionId]);
+  }, [showError, loadWorktrees, activeSessionId, settings.autoDeleteBranchOnWorktreeRemove]);
 
   const handleDeleteProject = useCallback(async (project: Project) => {
     const res = await API.projects.delete(project.id);

--- a/packages/ui/src/stores/settingsStore.ts
+++ b/packages/ui/src/stores/settingsStore.ts
@@ -17,6 +17,9 @@ export interface AppSettings {
   // Terminal
   terminalFontSize: number;
   terminalScrollback: number;
+
+  // Worktree
+  autoDeleteBranchOnWorktreeRemove: boolean;
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
@@ -29,6 +32,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   },
   terminalFontSize: 13,
   terminalScrollback: 1000,
+  autoDeleteBranchOnWorktreeRemove: false,
 };
 
 interface SettingsStore {

--- a/packages/ui/src/types/electron.d.ts
+++ b/packages/ui/src/types/electron.d.ts
@@ -92,7 +92,7 @@ export interface ElectronAPI {
       deletions: number;
       filesChanged: number;
     }>>>;
-    removeWorktree: (projectId: number, worktreePath: string, sessionId?: string | null) => Promise<IPCResponse<unknown>>;
+    removeWorktree: (projectId: number, worktreePath: string, sessionId?: string | null, autoDeleteBranch?: boolean) => Promise<IPCResponse<unknown>>;
     renameWorktree: (projectId: number, worktreePath: string, nextName: string, sessionId?: string | null) => Promise<IPCResponse<{ path: string } | unknown>>;
   };
 

--- a/packages/ui/src/utils/api.ts
+++ b/packages/ui/src/utils/api.ts
@@ -246,9 +246,9 @@ export class API {
       return window.electronAPI.projects.getWorktrees(projectId, sessionId);
     },
 
-    async removeWorktree(projectId: number, worktreePath: string, sessionId?: string | null) {
+    async removeWorktree(projectId: number, worktreePath: string, sessionId?: string | null, autoDeleteBranch?: boolean) {
       requireElectron();
-      return window.electronAPI.projects.removeWorktree(projectId, worktreePath, sessionId);
+      return window.electronAPI.projects.removeWorktree(projectId, worktreePath, sessionId, autoDeleteBranch);
     },
 
     async renameWorktree(projectId: number, worktreePath: string, nextName: string, sessionId?: string | null) {


### PR DESCRIPTION
## Summary

Add a setting to auto-delete the branch when removing a worktree and wire the IPC/UI flow to delete the branch using the worktree branch name.

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - _Not run (UI + IPC change)._

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):