### PR TITLE
Fix paste shortcuts in input bar

### DIFF
--- a/packages/desktop/src/infrastructure/ipc/app.ts
+++ b/packages/desktop/src/infrastructure/ipc/app.ts
@@ -1,4 +1,4 @@
-import { IpcMain, shell } from 'electron';
+import { IpcMain, clipboard, shell } from 'electron';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -48,6 +48,24 @@ export function registerAppHandlers(ipcMain: IpcMain, services: AppServices): vo
       return { success: false, error: error instanceof Error ? error.message : 'Failed to open path' };
     }
   });
+
+  ipcMain.handle('clipboard:read', () => {
+    try {
+      const text = clipboard.readText();
+      const image = clipboard.readImage();
+      return {
+        success: true,
+        data: {
+          text,
+          image: image.isEmpty() ? null : image.toDataURL(),
+        },
+      };
+    } catch (error) {
+      console.error('Failed to read clipboard:', error);
+      return { success: false, error: error instanceof Error ? error.message : 'Failed to read clipboard' };
+    }
+  });
+
 
   // Welcome tracking handler (for compatibility)
   ipcMain.handle('track-welcome-dismissed', () => {

--- a/packages/ui/src/components/layout/InputBar.test.tsx
+++ b/packages/ui/src/components/layout/InputBar.test.tsx
@@ -418,6 +418,117 @@ describe('InputBar - Cursor Position Tests', () => {
     });
   });
 
+  it('should paste text on Ctrl+V when not focused', async () => {
+    const user = userEvent.setup();
+    const invoke = vi.fn().mockResolvedValue({
+      success: true,
+      data: { text: 'PASTED', image: null },
+    });
+    (window as any).electronAPI = {
+      ...(window as any).electronAPI,
+      invoke,
+    };
+
+    render(
+      <InputBar
+        session={mockSession}
+        panelId="test-panel"
+        selectedTool="claude"
+        onSend={mockOnSend}
+        onCancel={mockOnCancel}
+        isProcessing={false}
+      />
+    );
+
+    const editor = await getEditor();
+
+    await user.click(editor);
+    await user.type(editor, 'hello');
+    setCaretInEditor(editor, 5);
+    await blurViaFocusSink(editor);
+
+    const pasteEvent = new KeyboardEvent('keydown', { key: 'v', ctrlKey: true, bubbles: true });
+    document.dispatchEvent(pasteEvent);
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('clipboard:read'));
+    await waitFor(() => expect(editor.textContent).toBe('helloPASTED'));
+  });
+
+  it('should paste text on Cmd+V when not focused', async () => {
+    const user = userEvent.setup();
+    const invoke = vi.fn().mockResolvedValue({
+      success: true,
+      data: { text: 'PASTED', image: null },
+    });
+    (window as any).electronAPI = {
+      ...(window as any).electronAPI,
+      invoke,
+    };
+
+    render(
+      <InputBar
+        session={mockSession}
+        panelId="test-panel"
+        selectedTool="claude"
+        onSend={mockOnSend}
+        onCancel={mockOnCancel}
+        isProcessing={false}
+      />
+    );
+
+    const editor = await getEditor();
+
+    await user.click(editor);
+    await user.type(editor, 'hello');
+    setCaretInEditor(editor, 5);
+    await blurViaFocusSink(editor);
+
+    const pasteEvent = new KeyboardEvent('keydown', { key: 'v', metaKey: true, bubbles: true });
+    document.dispatchEvent(pasteEvent);
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('clipboard:read'));
+    await waitFor(() => expect(editor.textContent).toBe('helloPASTED'));
+  });
+
+  it('should paste image on Ctrl+V when not focused', async () => {
+    const user = userEvent.setup();
+    const invoke = vi.fn().mockResolvedValue({
+      success: true,
+      data: { text: '', image: 'data:image/png;base64,TEST_DATA' },
+    });
+    (window as any).electronAPI = {
+      ...(window as any).electronAPI,
+      invoke,
+    };
+
+    render(
+      <InputBar
+        session={mockSession}
+        panelId="test-panel"
+        selectedTool="claude"
+        onSend={mockOnSend}
+        onCancel={mockOnCancel}
+        isProcessing={false}
+      />
+    );
+
+    const editor = await getEditor();
+
+    await user.click(editor);
+    await user.type(editor, 'hello');
+    setCaretInEditor(editor, 5);
+    await blurViaFocusSink(editor);
+
+    const pasteEvent = new KeyboardEvent('keydown', { key: 'v', ctrlKey: true, bubbles: true });
+    document.dispatchEvent(pasteEvent);
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('clipboard:read'));
+    await waitFor(() => {
+      const imageTag = editor.querySelector('[data-image-id]');
+      expect(imageTag).toBeInTheDocument();
+    });
+  });
+
   it('should select all input content on Ctrl+A when not focused', async () => {
     const user = userEvent.setup();
 


### PR DESCRIPTION
## Summary

- fix Ctrl+V paste handling to insert from clipboard even when input is focused
- keep Cmd+V native while supporting global paste when unfocused
- cover Ctrl/Cmd+V paste with clipboard read tests

## Tests

- [x] Unit Test (
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):