### PR TITLE
Fix Edit tool showing full file instead of diff in timeline

### DIFF
--- a/packages/desktop/src/executors/base/DiffMetadataExtractor.ts
+++ b/packages/desktop/src/executors/base/DiffMetadataExtractor.ts
@@ -64,23 +64,9 @@ export class DiffMetadataExtractor {
 
     if (!filePath || oldString === undefined || newString === undefined) return null;
 
-    // Read the current file content to get the full file after edit
-    const currentContent = await this.readFileIfExists(filePath);
-
-    // If we can read the file, the edit has been applied, so currentContent is the new full content
-    // We need to reconstruct the old full content by reversing the edit
-    if (currentContent !== null) {
-      // The file now contains newString where oldString used to be
-      // Reconstruct old content: replace newString back with oldString
-      const fullOldContent = currentContent.replace(newString, oldString);
-      return [{
-        filePath,
-        oldString: fullOldContent,
-        newString: currentContent,
-      }];
-    }
-
-    // Fallback: return the partial strings if file can't be read
+    // For Edit tool, we should show the diff between oldString and newString
+    // NOT the entire file content. The Edit tool already provides the exact
+    // strings that were changed, so we use them directly.
     return [{
       filePath,
       oldString,


### PR DESCRIPTION
## Summary

Fixed an issue where the Edit tool was displaying the entire file content instead of just the diff in the timeline view.

The problem was in `DiffMetadataExtractor.extractClaudeEdit()` which attempted to reconstruct the full file content by reading the current file and using a simple string replacement. This approach was unreliable and caused the timeline to show complete files rather than focused diffs.

The fix simplifies the logic to directly use the `oldString` and `newString` provided by the Edit tool, which are the exact strings that were changed. This allows the `InlineDiffViewer` component to properly display line-by-line diffs.

## Tests

- [x] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

Updated and verified all 20 unit tests in `DiffMetadataExtractor.test.ts` pass successfully.

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):