### PR TITLE
Fix terminal OSC response echo bug

### DIFF
--- a/packages/ui/src/components/layout/TerminalPanel.test.tsx
+++ b/packages/ui/src/components/layout/TerminalPanel.test.tsx
@@ -130,4 +130,270 @@ describe('TerminalPanel', () => {
 
     await waitFor(() => expect(terminalInstances[0].writes).toContain('hello'));
   });
+
+  describe('OSC Response Filtering', () => {
+    it('filters OSC 11 color query responses with BEL terminator', async () => {
+      const outputHandlers: Array<(event: any) => void> = [];
+      (window as any).electronAPI = {
+        ...(window as any).electronAPI,
+        events: {
+          onTerminalOutput: (handler: (event: any) => void) => {
+            outputHandlers.push(handler);
+            return () => undefined;
+          },
+        },
+      };
+
+      render(<TerminalPanel sessionId="s1" panelId="p1" height={200} />);
+
+      await waitFor(() => expect(terminalInstances.length).toBe(1));
+      await waitFor(() => expect(outputHandlers.length).toBe(1));
+
+      // Send output with OSC 11 response (background color query)
+      outputHandlers[0]({
+        sessionId: 's1',
+        panelId: 'p1',
+        type: 'stdout',
+        data: '➜  test \x1b]11;rgb:2828/2c2c/3434\x07\n',
+      });
+
+      await waitFor(() => {
+        const writes = terminalInstances[0].writes;
+        expect(writes.length).toBeGreaterThan(0);
+        const lastWrite = writes[writes.length - 1];
+        // OSC response should be filtered out
+        expect(lastWrite).toBe('➜  test \n');
+        expect(lastWrite).not.toContain('\x1b]11');
+      });
+    });
+
+    it('filters OSC 11 color query responses with ST terminator', async () => {
+      const outputHandlers: Array<(event: any) => void> = [];
+      (window as any).electronAPI = {
+        ...(window as any).electronAPI,
+        events: {
+          onTerminalOutput: (handler: (event: any) => void) => {
+            outputHandlers.push(handler);
+            return () => undefined;
+          },
+        },
+      };
+
+      render(<TerminalPanel sessionId="s1" panelId="p1" height={200} />);
+
+      await waitFor(() => expect(terminalInstances.length).toBe(1));
+      await waitFor(() => expect(outputHandlers.length).toBe(1));
+
+      // Send output with OSC response using ST terminator (ESC \)
+      outputHandlers[0]({
+        sessionId: 's1',
+        panelId: 'p1',
+        type: 'stdout',
+        data: 'test\x1b]11;rgb:c8c8/cccc/d4d4\x1b\\output',
+      });
+
+      await waitFor(() => {
+        const writes = terminalInstances[0].writes;
+        expect(writes.length).toBeGreaterThan(0);
+        const lastWrite = writes[writes.length - 1];
+        expect(lastWrite).toBe('testoutput');
+        expect(lastWrite).not.toContain('\x1b]11');
+      });
+    });
+
+    it('filters multiple OSC responses in single output', async () => {
+      const outputHandlers: Array<(event: any) => void> = [];
+      (window as any).electronAPI = {
+        ...(window as any).electronAPI,
+        events: {
+          onTerminalOutput: (handler: (event: any) => void) => {
+            outputHandlers.push(handler);
+            return () => undefined;
+          },
+        },
+      };
+
+      render(<TerminalPanel sessionId="s1" panelId="p1" height={200} />);
+
+      await waitFor(() => expect(terminalInstances.length).toBe(1));
+      await waitFor(() => expect(outputHandlers.length).toBe(1));
+
+      // Send output with multiple OSC responses
+      outputHandlers[0]({
+        sessionId: 's1',
+        panelId: 'p1',
+        type: 'stdout',
+        data: '\x1b]10;rgb:ffff/ffff/ffff\x07\x1b]11;rgb:0000/0000/0000\x07normal text',
+      });
+
+      await waitFor(() => {
+        const writes = terminalInstances[0].writes;
+        expect(writes.length).toBeGreaterThan(0);
+        const lastWrite = writes[writes.length - 1];
+        expect(lastWrite).toBe('normal text');
+        expect(lastWrite).not.toContain('\x1b]10');
+        expect(lastWrite).not.toContain('\x1b]11');
+      });
+    });
+
+    it('preserves normal ANSI color codes (CSI sequences)', async () => {
+      const outputHandlers: Array<(event: any) => void> = [];
+      (window as any).electronAPI = {
+        ...(window as any).electronAPI,
+        events: {
+          onTerminalOutput: (handler: (event: any) => void) => {
+            outputHandlers.push(handler);
+            return () => undefined;
+          },
+        },
+      };
+
+      render(<TerminalPanel sessionId="s1" panelId="p1" height={200} />);
+
+      await waitFor(() => expect(terminalInstances.length).toBe(1));
+      await waitFor(() => expect(outputHandlers.length).toBe(1));
+
+      // Send output with normal ANSI color codes
+      outputHandlers[0]({
+        sessionId: 's1',
+        panelId: 'p1',
+        type: 'stdout',
+        data: '\x1b[36mCyan text\x1b[0m',
+      });
+
+      await waitFor(() => {
+        const writes = terminalInstances[0].writes;
+        expect(writes.length).toBeGreaterThan(0);
+        const lastWrite = writes[writes.length - 1];
+        // ANSI color codes should be preserved
+        expect(lastWrite).toBe('\x1b[36mCyan text\x1b[0m');
+      });
+    });
+
+    it('filters OSC responses while preserving ANSI codes', async () => {
+      const outputHandlers: Array<(event: any) => void> = [];
+      (window as any).electronAPI = {
+        ...(window as any).electronAPI,
+        events: {
+          onTerminalOutput: (handler: (event: any) => void) => {
+            outputHandlers.push(handler);
+            return () => undefined;
+          },
+        },
+      };
+
+      render(<TerminalPanel sessionId="s1" panelId="p1" height={200} />);
+
+      await waitFor(() => expect(terminalInstances.length).toBe(1));
+      await waitFor(() => expect(outputHandlers.length).toBe(1));
+
+      // Send output with both OSC responses and ANSI codes
+      outputHandlers[0]({
+        sessionId: 's1',
+        panelId: 'p1',
+        type: 'stdout',
+        data: '\x1b[1mBold\x1b]11;rgb:1111/2222/3333\x07\x1b[0m',
+      });
+
+      await waitFor(() => {
+        const writes = terminalInstances[0].writes;
+        expect(writes.length).toBeGreaterThan(0);
+        const lastWrite = writes[writes.length - 1];
+        // OSC should be filtered, ANSI preserved
+        expect(lastWrite).toBe('\x1b[1mBold\x1b[0m');
+        expect(lastWrite).not.toContain('\x1b]11');
+      });
+    });
+
+    it('filters OSC responses from historical terminal output', async () => {
+      (API.sessions.getTerminalOutputs as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true,
+        data: [
+          { id: 1, type: 'stdout', data: 'line 1\n' },
+          { id: 2, type: 'stdout', data: '\x1b]11;rgb:2828/2c2c/3434\x07' },
+          { id: 3, type: 'stdout', data: 'line 2\n' },
+        ],
+      });
+
+      render(<TerminalPanel sessionId="s1" panelId="p1" height={200} />);
+
+      await waitFor(() => expect(terminalInstances.length).toBe(1));
+      await waitFor(() => {
+        const writes = terminalInstances[0].writes;
+        expect(writes.length).toBeGreaterThan(0);
+        const combinedWrites = writes.join('');
+        expect(combinedWrites).toContain('line 1');
+        expect(combinedWrites).toContain('line 2');
+        expect(combinedWrites).not.toContain('\x1b]11');
+      });
+    });
+
+    it('filters OSC 10 (foreground color) responses', async () => {
+      const outputHandlers: Array<(event: any) => void> = [];
+      (window as any).electronAPI = {
+        ...(window as any).electronAPI,
+        events: {
+          onTerminalOutput: (handler: (event: any) => void) => {
+            outputHandlers.push(handler);
+            return () => undefined;
+          },
+        },
+      };
+
+      render(<TerminalPanel sessionId="s1" panelId="p1" height={200} />);
+
+      await waitFor(() => expect(terminalInstances.length).toBe(1));
+      await waitFor(() => expect(outputHandlers.length).toBe(1));
+
+      // Send output with OSC 10 response (foreground color query)
+      outputHandlers[0]({
+        sessionId: 's1',
+        panelId: 'p1',
+        type: 'stdout',
+        data: 'text\x1b]10;rgb:ffff/ffff/ffff\x07more text',
+      });
+
+      await waitFor(() => {
+        const writes = terminalInstances[0].writes;
+        expect(writes.length).toBeGreaterThan(0);
+        const lastWrite = writes[writes.length - 1];
+        expect(lastWrite).toBe('textmore text');
+        expect(lastWrite).not.toContain('\x1b]10');
+      });
+    });
+
+    it('filters OSC 12 (cursor color) responses', async () => {
+      const outputHandlers: Array<(event: any) => void> = [];
+      (window as any).electronAPI = {
+        ...(window as any).electronAPI,
+        events: {
+          onTerminalOutput: (handler: (event: any) => void) => {
+            outputHandlers.push(handler);
+            return () => undefined;
+          },
+        },
+      };
+
+      render(<TerminalPanel sessionId="s1" panelId="p1" height={200} />);
+
+      await waitFor(() => expect(terminalInstances.length).toBe(1));
+      await waitFor(() => expect(outputHandlers.length).toBe(1));
+
+      // Send output with OSC 12 response (cursor color query)
+      outputHandlers[0]({
+        sessionId: 's1',
+        panelId: 'p1',
+        type: 'stdout',
+        data: 'cursor\x1b]12;rgb:61af/efef/0000\x07test',
+      });
+
+      await waitFor(() => {
+        const writes = terminalInstances[0].writes;
+        expect(writes.length).toBeGreaterThan(0);
+        const lastWrite = writes[writes.length - 1];
+        expect(lastWrite).toBe('cursortest');
+        expect(lastWrite).not.toContain('\x1b]12');
+      });
+    });
+  });
 });

--- a/packages/ui/src/components/layout/oscFilter.test.ts
+++ b/packages/ui/src/components/layout/oscFilter.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import { filterOSCResponses } from './oscFilter';
+
+describe('filterOSCResponses', () => {
+  describe('OSC 11 (Background Color) Responses', () => {
+    it('filters OSC 11 response with BEL terminator', () => {
+      const input = '➜  test \x1b]11;rgb:2828/2c2c/3434\x07\n';
+      const expected = '➜  test \n';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+
+    it('filters OSC 11 response with ST terminator', () => {
+      const input = 'test\x1b]11;rgb:c8c8/cccc/d4d4\x1b\\output';
+      const expected = 'testoutput';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+
+    it('filters OSC 11 response in the middle of text', () => {
+      const input = 'before\x1b]11;rgb:1111/2222/3333\x07after';
+      const expected = 'beforeafter';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+  });
+
+  describe('OSC 10 (Foreground Color) Responses', () => {
+    it('filters OSC 10 response with BEL terminator', () => {
+      const input = 'text\x1b]10;rgb:ffff/ffff/ffff\x07more text';
+      const expected = 'textmore text';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+
+    it('filters OSC 10 response with ST terminator', () => {
+      const input = 'start\x1b]10;rgb:0000/0000/0000\x1b\\end';
+      const expected = 'startend';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+  });
+
+  describe('OSC 12 (Cursor Color) Responses', () => {
+    it('filters OSC 12 response with BEL terminator', () => {
+      const input = 'cursor\x1b]12;rgb:61af/efef/0000\x07test';
+      const expected = 'cursortest';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+
+    it('filters OSC 12 response with ST terminator', () => {
+      const input = 'a\x1b]12;rgb:ffff/0000/0000\x1b\\b';
+      const expected = 'ab';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+  });
+
+  describe('Multiple OSC Responses', () => {
+    it('filters multiple OSC responses in single string', () => {
+      const input = '\x1b]10;rgb:ffff/ffff/ffff\x07\x1b]11;rgb:0000/0000/0000\x07normal text';
+      const expected = 'normal text';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+
+    it('filters mixed OSC 10, 11, and 12 responses', () => {
+      const input = 'a\x1b]10;rgb:1111/1111/1111\x07b\x1b]11;rgb:2222/2222/2222\x07c\x1b]12;rgb:3333/3333/3333\x07d';
+      const expected = 'abcd';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+
+    it('filters consecutive OSC responses', () => {
+      const input = '\x1b]11;rgb:1111/2222/3333\x07\x1b]11;rgb:4444/5555/6666\x07\x1b]11;rgb:7777/8888/9999\x07';
+      const expected = '';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+  });
+
+  describe('ANSI Color Codes Preservation', () => {
+    it('preserves normal ANSI color codes (CSI sequences)', () => {
+      const input = '\x1b[36mCyan text\x1b[0m';
+      expect(filterOSCResponses(input)).toBe(input);
+    });
+
+    it('preserves ANSI bold codes', () => {
+      const input = '\x1b[1mBold text\x1b[0m';
+      expect(filterOSCResponses(input)).toBe(input);
+    });
+
+    it('preserves ANSI 256-color codes', () => {
+      const input = '\x1b[38;5;214mOrange\x1b[0m';
+      expect(filterOSCResponses(input)).toBe(input);
+    });
+
+    it('preserves ANSI RGB color codes', () => {
+      const input = '\x1b[38;2;255;100;50mRGB Color\x1b[0m';
+      expect(filterOSCResponses(input)).toBe(input);
+    });
+  });
+
+  describe('Mixed OSC and ANSI Sequences', () => {
+    it('filters OSC while preserving ANSI codes', () => {
+      const input = '\x1b[1mBold\x1b]11;rgb:1111/2222/3333\x07\x1b[0m';
+      const expected = '\x1b[1mBold\x1b[0m';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+
+    it('handles complex mixed sequences', () => {
+      const input = '\x1b[36m\x1b]10;rgb:ffff/ffff/ffff\x07Cyan\x1b]11;rgb:0000/0000/0000\x07\x1b[0m';
+      const expected = '\x1b[36mCyan\x1b[0m';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+
+    it('preserves ANSI before and after OSC filtering', () => {
+      const input = '\x1b[32mGreen\x1b[0m\x1b]11;rgb:1234/5678/9abc\x07\x1b[31mRed\x1b[0m';
+      const expected = '\x1b[32mGreen\x1b[0m\x1b[31mRed\x1b[0m';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('handles empty string', () => {
+      expect(filterOSCResponses('')).toBe('');
+    });
+
+    it('handles string with no OSC sequences', () => {
+      const input = 'normal text without any escape sequences';
+      expect(filterOSCResponses(input)).toBe(input);
+    });
+
+    it('handles OSC response at start of string', () => {
+      const input = '\x1b]11;rgb:1111/2222/3333\x07text';
+      const expected = 'text';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+
+    it('handles OSC response at end of string', () => {
+      const input = 'text\x1b]11;rgb:1111/2222/3333\x07';
+      const expected = 'text';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+
+    it('handles only OSC response', () => {
+      const input = '\x1b]11;rgb:1111/2222/3333\x07';
+      const expected = '';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+
+    it('handles newlines and special characters', () => {
+      const input = 'line1\n\x1b]11;rgb:1111/2222/3333\x07line2\r\n';
+      const expected = 'line1\nline2\r\n';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+
+    it('handles unicode characters', () => {
+      const input = '➜ 🚀 \x1b]11;rgb:1111/2222/3333\x07 测试';
+      const expected = '➜ 🚀  测试';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+  });
+
+  describe('Real-world Shell Prompt Scenarios', () => {
+    it('filters Oh My Zsh color query responses', () => {
+      const input = '➜  project git:(main) \x1b]11;rgb:2828/2c2c/3434\x07✗ ';
+      const expected = '➜  project git:(main) ✗ ';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+
+    it('filters Powerlevel10k initialization sequences', () => {
+      const input = '\x1b]10;rgb:c8c8/cccc/d4d4\x07\x1b]11;rgb:2828/2c2c/3434\x07\x1b]12;rgb:61af/efef/0000\x07$ ';
+      const expected = '$ ';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+
+    it('handles Starship prompt with color queries', () => {
+      const input = '\x1b]11;rgb:1e1e/1e1e/1e1e\x07\x1b[1;32m❯\x1b[0m ';
+      const expected = '\x1b[1;32m❯\x1b[0m ';
+      expect(filterOSCResponses(input)).toBe(expected);
+    });
+  });
+
+  describe('Issue #82 Regression Tests', () => {
+    it('prevents the bug reported in issue #82', () => {
+      // The actual bug sequence from the issue
+      const input = '➜  pretoria-wsmv5f5n git:(pretoria-wsmv5f5n) ✗ \x1b]11;rgb:2828/2c2c/3434\x07\n';
+      const result = filterOSCResponses(input);
+
+      // Should not contain the OSC response
+      expect(result).not.toContain('\x1b]11');
+      expect(result).not.toContain('rgb:2828/2c2c/3434');
+
+      // Should preserve the prompt
+      expect(result).toContain('➜  pretoria-wsmv5f5n');
+      expect(result).toContain('git:(pretoria-wsmv5f5n)');
+      expect(result).toContain('✗');
+    });
+
+    it('handles multiple terminal open/close cycles', () => {
+      // Simulating multiple terminal opens that each send color queries
+      const inputs = [
+        '\x1b]11;rgb:2828/2c2c/3434\x07prompt1$ ',
+        '\x1b]11;rgb:2828/2c2c/3434\x07prompt2$ ',
+        '\x1b]11;rgb:2828/2c2c/3434\x07prompt3$ ',
+      ];
+
+      inputs.forEach((input, index) => {
+        const result = filterOSCResponses(input);
+        expect(result).toBe(`prompt${index + 1}$ `);
+        expect(result).not.toContain('\x1b]11');
+      });
+    });
+  });
+});

--- a/packages/ui/src/components/layout/oscFilter.ts
+++ b/packages/ui/src/components/layout/oscFilter.ts
@@ -1,0 +1,38 @@
+/**
+ * Filters out OSC (Operating System Command) response sequences that should not be displayed.
+ * These are responses to terminal queries (e.g., color queries) that get echoed back incorrectly.
+ *
+ * Common OSC responses to filter:
+ * - OSC 10/11/12: Foreground/Background/Cursor color query responses
+ * - Format: ESC ] Ps ; Pt (ST|BEL) where ST = ESC \ and BEL = \x07
+ *
+ * Background:
+ * When shells initialize (especially with modern themes like Oh My Zsh, Powerlevel10k, Starship),
+ * they send OSC queries to detect terminal capabilities. The terminal responds with color values,
+ * but these responses can be incorrectly echoed to the display if not filtered.
+ *
+ * @param data Raw terminal output data
+ * @returns Filtered data with OSC responses removed
+ *
+ * @example
+ * ```typescript
+ * // Filter OSC 11 background color response
+ * filterOSCResponses('text\x1b]11;rgb:2828/2c2c/3434\x07more')
+ * // Returns: 'textmore'
+ *
+ * // Preserve normal ANSI color codes
+ * filterOSCResponses('\x1b[36mCyan\x1b[0m')
+ * // Returns: '\x1b[36mCyan\x1b[0m'
+ * ```
+ */
+export const filterOSCResponses = (data: string): string => {
+  // Filter OSC sequences: \x1b]...\x07 or \x1b]...\x1b\\
+  // This regex matches OSC sequences that are responses to queries
+  // Pattern: ESC ] digits ; response (BEL or ST)
+  // - \x1b\] : ESC followed by ]
+  // - [0-9]+ : One or more digits (OSC command number)
+  // - ; : Semicolon separator
+  // - [^\x07\x1b]* : Any characters except BEL or ESC
+  // - (?:\x07|\x1b\\) : Either BEL (\x07) or ST (ESC \)
+  return data.replace(/\x1b\][0-9]+;[^\x07\x1b]*(?:\x07|\x1b\\)/g, '');
+};


### PR DESCRIPTION
## Summary

Fixes the terminal bug where OSC (Operating System Command) response sequences are incorrectly displayed when opening/closing the terminal using keyboard shortcuts. Modern shell themes (Oh My Zsh, Powerlevel10k, Starship) send color queries during initialization, and the terminal responses were being echoed to the display instead of being consumed silently.

This PR implements a comprehensive filtering solution that strips OSC response sequences while preserving normal ANSI color codes.

- fixes: #82

## Tests

- [x] Unit Test - 29 unit tests for OSC filtering edge cases
- [x] Logic Test - 8 integration tests for TerminalPanel OSC handling
- [ ] Benchmark Test
- [ ] No Test

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):

## Changes

- Added `filterOSCResponses` utility function to strip OSC color query responses
- Applied filtering to real-time, historical, and pending terminal output paths
- Configured xterm.js `windowOptions` to prevent OSC manipulation
- Added comprehensive test coverage (37 total tests)
- Preserves ANSI color codes (CSI sequences) while filtering OSC responses

## Testing

All tests pass:
- ✅ 29 unit tests for OSC filtering (oscFilter.test.ts)
- ✅ 8 integration tests for TerminalPanel (TerminalPanel.test.tsx)
- ✅ Full UI test suite (391 tests total)