### PR TITLE
Update blog post link to Databend's Snowtree category

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ make build     # Build packages
 
 ## Learn More
 
-[Snowtree: Review-Driven Safe AI Coding](https://www.bohutang.me/2026/01/10/snowtree-review-driven-safe-ai-coding/)
+[Snowtree: Databend's Best Practices for AI-Native Development](https://www.databend.com/blog/category-engineering/snowtree/)
 
 ## License
 


### PR DESCRIPTION
## Summary

Updated the "Learn More" section in README.md to point to Databend's Snowtree blog category page instead of a single blog post. This provides readers with access to all Snowtree-related articles.

Changes:
- Updated blog post URL to https://www.databend.com/blog/category-engineering/snowtree/
- Changed link title to "Snowtree: Databend's Best Practices for AI-Native Development"

## Tests

- [ ] No Test - Documentation update only

## Type of change

- [x] Documentation Update