### PR TITLE
Configure macOS code signing and notarization for CI releases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# macOS Code Signing (CI only)
+# Leave these empty for local development - the app will build without signing
+# Set these in CI/CD for signed releases
+
+# Option 1: Using Apple ID (legacy method)
+# APPLE_ID=your-apple-id@email.com
+# APPLE_APP_SPECIFIC_PASSWORD=xxxx-xxxx-xxxx-xxxx
+# APPLE_TEAM_ID=YOUR_TEAM_ID
+
+# Option 2: Using App Store Connect API Key (recommended)
+# APPLE_API_KEY=path/to/AuthKey_XXXXXXXXXX.p8
+# APPLE_API_KEY_ID=XXXXXXXXXX
+# APPLE_API_ISSUER=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+
+# Code signing identity (will auto-detect if not set)
+# CSC_NAME=Developer ID Application: Your Name (TEAM_ID)
+
+# Or use certificate file
+# CSC_LINK=path/to/certificate.p12
+# CSC_KEY_PASSWORD=certificate-password

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,6 +261,12 @@ jobs:
         run: |
           set -euo pipefail
           "${GITHUB_WORKSPACE}/node_modules/.bin/electron-builder" --projectDir "${RELEASE_APP_DIR}" --publish never
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
 
       - name: Verify packaged app contains core (macOS)
         if: runner.os == 'macOS'
@@ -276,6 +282,34 @@ jobs:
           echo "Verifying asar: ${APP_ASAR}"
           "${GITHUB_WORKSPACE}/node_modules/.bin/asar" list "${APP_ASAR}" | grep -q "node_modules/@snowtree/core/dist-cjs/types/models.js"
 
+      - name: Verify code signing (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          ZIP="$(ls -1 "${RELEASE_APP_DIR}/dist-electron/"*macOS-arm64.zip | head -n 1)"
+          TMP_DIR="${RUNNER_TEMP}/verify-signing"
+          rm -rf "${TMP_DIR}"
+          mkdir -p "${TMP_DIR}"
+          unzip -q "${ZIP}" -d "${TMP_DIR}"
+          APP="$(find "${TMP_DIR}" -name 'snowtree.app' -type d | head -n 1)"
+
+          echo "Verifying code signature for: ${APP}"
+          codesign -dv --verbose=4 "${APP}" 2>&1 | tee /tmp/codesign-output.txt
+
+          # Check if signed
+          if ! codesign -v "${APP}" 2>&1; then
+            echo "❌ App is not properly signed"
+            exit 1
+          fi
+
+          echo "✅ App is properly signed"
+
+          # Verify DMG signature
+          DMG="$(ls -1 "${RELEASE_APP_DIR}/dist-electron/"*macOS-arm64.dmg | head -n 1)"
+          echo "Verifying DMG signature: ${DMG}"
+          codesign -dv --verbose=4 "${DMG}" 2>&1 || echo "⚠️  DMG signature check (non-fatal)"
+
       - name: Publish to GitHub Releases
         shell: bash
         run: |
@@ -283,6 +317,11 @@ jobs:
           "${GITHUB_WORKSPACE}/node_modules/.bin/electron-builder" --projectDir "${RELEASE_APP_DIR}" --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
 
       - name: Ensure release assets uploaded (gh upload)
         shell: bash

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -95,13 +95,13 @@
     "mac": {
       "category": "public.app-category.developer-tools",
       "icon": "packages/desktop/assets/icon.icns",
-      "identity": null,
-      "hardenedRuntime": false,
+      "hardenedRuntime": true,
       "gatekeeperAssess": false,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist",
       "signIgnore": [
         "node_modules/@anthropic-ai/claude-code/vendor/.*\\.jar$"
       ],
-      "notarize": false,
       "target": [
         {
           "target": "zip",


### PR DESCRIPTION
## Summary

This PR configures macOS code signing and notarization for CI releases. When building releases in CI, the application will now be properly signed with a Developer ID certificate and notarized by Apple, ensuring users can install and run the app without security warnings.

Changes include:
- Updated `package.json` to enable `hardenedRuntime` and configure entitlements
- Added `build/entitlements.mac.plist` with required permissions for Electron apps
- Modified `.github/workflows/release.yml` to pass signing secrets to electron-builder
- Added verification step to confirm code signing succeeded
- Created `.env.example` documenting required environment variables

Local development builds remain unsigned (no certificate required). Signing only occurs in CI when the appropriate secrets are configured.

## Tests

- [x] No Test - Configuration change only, will be verified in next release build

## Type of change

- [x] New Feature (non-breaking change which adds functionality)
- [x] Documentation Update