### PR TITLE
Fix macOS notarization by decoding base64 Apple API key to file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,6 +256,18 @@ jobs:
           "${GITHUB_WORKSPACE}/node_modules/.bin/electron-builder" install-app-deps
           popd
 
+      - name: Prepare Apple API Key
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          APPLE_API_KEY_PATH="${RUNNER_TEMP}/AuthKey_${APPLE_API_KEY_ID}.p8"
+          echo "${APPLE_API_KEY}" | base64 -d > "${APPLE_API_KEY_PATH}"
+          echo "APPLE_API_KEY_PATH=${APPLE_API_KEY_PATH}" >> "${GITHUB_ENV}"
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+
       - name: Build artifacts (no publish)
         shell: bash
         run: |
@@ -264,7 +276,7 @@ jobs:
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
 
@@ -319,7 +331,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY: ${{ runner.os == 'macOS' && env.APPLE_API_KEY_PATH || '' }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
 


### PR DESCRIPTION
## Summary

Fixed the CI publish notarization error on macOS. The issue was that the `APPLE_API_KEY` secret contains base64-encoded content, but was being passed directly to electron-builder/notarytool, which expects a file path. This caused notarytool to fail with "The file couldn't be opened because it doesn't exist."

The fix adds a preparation step that:
1. Decodes the base64-encoded Apple API key from the secret
2. Writes it to a temporary .p8 file with the correct naming convention
3. Passes the file path to electron-builder instead of the raw secret value

## Tests

- [ ] Unit Test
- [ ] Logic Test
- [ ] Benchmark Test
- [x] No Test - CI workflow change, will be tested in the next release workflow run

## Type of change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [ ] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):