### PR TITLE
Set diff context expansion to 20 lines per click

### DIFF
--- a/packages/ui/src/components/panels/diff/PierreDiffViewer.tsx
+++ b/packages/ui/src/components/panels/diff/PierreDiffViewer.tsx
@@ -553,6 +553,7 @@ const FileCard = memo(function FileCard({
     const base = {
       diffStyle: 'unified' as const,
       hunkSeparators: 'line-info' as const,
+      expansionLineCount: 20,
       overflow: 'scroll' as const,
       themeType: themeType as 'light' | 'dark',
       disableFileHeader: true,
@@ -570,6 +571,7 @@ const FileCard = memo(function FileCard({
       return {
         diffStyle: base.diffStyle,
         hunkSeparators: base.hunkSeparators,
+        expansionLineCount: base.expansionLineCount,
         overflow: base.overflow,
         themeType: base.themeType,
         disableFileHeader: true,


### PR DESCRIPTION
Instead of expanding all context lines at once when clicking expand in the diff viewer, use incremental expansion of 20 lines per click (matching GitHub/GitLab behavior).

This leverages the built-in `expansionLineCount` option in `@pierre/diffs` which defaults to 100 — too large for most gaps, causing everything to expand in one click.